### PR TITLE
Update deploy excludes and migration column type

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             cd ~/hibarr-crm
             git pull origin main
-            rsync -av --exclude 'public/user-uploads' --exclude 'storage/app/modules_statuses.json' --exclude 'Modules' --exclude '.env' ~/hibarr-crm/ /var/www/html
+            rsync -av --exclude 'public/user-uploads' --exclude 'public/favicon.ico' --exclude 'storage/app/modules_statuses.json' --exclude 'Modules' --exclude '.env' ~/hibarr-crm/ /var/www/html
             cd /var/www/html
             composer install --no-interaction --prefer-dist --optimize-autoloader
             npm install

--- a/database/migrations/2025_01_15_000001_add_custom_field_category_id_to_custom_fields_table.php
+++ b/database/migrations/2025_01_15_000001_add_custom_field_category_id_to_custom_fields_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('custom_fields', function (Blueprint $table) {
-            $table->unsignedInteger('custom_field_category_id')->nullable()->after('custom_field_group_id');
+            $table->unsignedBigInteger('custom_field_category_id')->nullable()->after('custom_field_group_id');
             $table->foreign('custom_field_category_id')->references('id')->on('custom_field_categories')->onDelete('set null')->onUpdate('cascade');
         });
     }


### PR DESCRIPTION
Added 'public/favicon.ico' to the rsync exclude list in the deploy workflow. Changed 'custom_field_category_id' column type from unsignedInteger to unsignedBigInteger in the related migration for better compatibility with referenced table.