### PR TITLE
Remove optimize step from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,3 @@ jobs:
             npm install
             npm run production
             php artisan migrate --force
-            php artisan optimize


### PR DESCRIPTION
The 'php artisan optimize' command has been removed from the deployment workflow. This may be due to changes in Laravel's optimization process or to streamline the deployment steps.