### PR TITLE
Refactor lead custom field category tabs and display

### DIFF
--- a/app/Http/Controllers/LeadContactController.php
+++ b/app/Http/Controllers/LeadContactController.php
@@ -79,6 +79,9 @@ class LeadContactController extends AccountBaseController
 
         $this->leadId = $id;
 
+        // Get custom field categories for lead module
+        $this->customFieldCategories = $this->getLeadCustomFieldCategories();
+
         $getCustomFieldGroupsWithFields = $this->leadContact->getCustomFieldGroupsWithFields();
         if ($getCustomFieldGroupsWithFields) {
             $this->fields = $getCustomFieldGroupsWithFields->fields;
@@ -189,14 +192,7 @@ class LeadContactController extends AccountBaseController
         $this->salutations = Salutation::cases();
 
         // Get custom field categories for lead module
-        $leadCustomFieldGroup = CustomFieldGroup::where('model', Lead::CUSTOM_FIELD_MODEL)->first();
-        if ($leadCustomFieldGroup) {
-            $this->customFieldCategories = CustomFieldCategory::where('custom_field_group_id', $leadCustomFieldGroup->id)
-                ->where('company_id', company()->id)
-                ->get();
-        } else {
-            $this->customFieldCategories = collect();
-        }
+        $this->customFieldCategories = $this->getLeadCustomFieldCategories();
 
         // To create deal from lead
 
@@ -344,14 +340,7 @@ class LeadContactController extends AccountBaseController
 
 
         // Get custom field categories for lead module
-        $leadCustomFieldGroup = CustomFieldGroup::where('model', Lead::CUSTOM_FIELD_MODEL)->first();
-        if ($leadCustomFieldGroup) {
-            $this->customFieldCategories = CustomFieldCategory::where('custom_field_group_id', $leadCustomFieldGroup->id)
-                ->where('company_id', company()->id)
-                ->get();
-        } else {
-            $this->customFieldCategories = collect();
-        }
+        $this->customFieldCategories = $this->getLeadCustomFieldCategories();
 
         if (request()->ajax()) {
             $html = view('lead-contact.ajax.edit', $this->data)->render();
@@ -549,5 +538,21 @@ class LeadContactController extends AccountBaseController
                 $leadProduct->save();
             }
         }
+    }
+
+    /**
+     * Get custom field categories for the lead module.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    private function getLeadCustomFieldCategories()
+    {
+        $leadCustomFieldGroup = CustomFieldGroup::where('model', Lead::CUSTOM_FIELD_MODEL)->first();
+        if ($leadCustomFieldGroup) {
+            return CustomFieldCategory::where('custom_field_group_id', $leadCustomFieldGroup->id)
+                ->where('company_id', company()->id)
+                ->get();
+        }
+        return collect();
     }
 }

--- a/resources/views/components/cards/card-header.blade.php
+++ b/resources/views/components/cards/card-header.blade.php
@@ -1,8 +1,13 @@
-<div class="card-header bg-white border-0  d-flex justify-content-between pt-4">
+@props(['customFieldCategories' => null])
+<div class="card-header bg-white border-0  flex flex-wrap justify-between pt-4 gap-4 px-0">
     <h4 class="f-18 f-w-500 mb-0">{{ $slot }}</h4>
+    <div class="flex items-center gap-4">
+        @if ($customFieldCategories)
+            {!! $customFieldCategories !!}
+        @endif
 
-    @if($action)
-        {!! $action !!}
-    @endif
-
+        @if ($action)
+            {!! $action !!}
+        @endif
+    </div>
 </div>

--- a/resources/views/components/cards/data-row.blade.php
+++ b/resources/views/components/cards/data-row.blade.php
@@ -1,11 +1,11 @@
 @if (!$html)
-    <div class="col-12 px-0 pb-3 d-lg-flex d-md-flex d-block">
+    <div class="col-12 col-md-6 px-0 pb-3 d-lg-flex d-md-flex d-block">
         <p class="mb-0 text-lightest f-14 w-30  {{ $labelClasses }}">{{ $label }}</p>
-        <p class="mb-0 text-dark-grey f-14 w-70 text-wrap {{ $otherClasses }}">{!! $value !!}</p>
+        <p class="mb-0 f-14 w-70 text-wrap {{ $otherClasses }}">{!! $value !!}</p>
     </div>
 @else
-    <div class="col-12 px-0 pb-3 d-lg-flex d-md-flex d-block">
+    <div class="col-12 col-md-6 px-0 pb-3 d-lg-flex d-md-flex d-block">
         <p class="mb-0 text-lightest f-14 w-30  {{ $labelClasses }}">{{ $label }}</p>
-        <div class="mb-0 text-dark-grey f-14 w-70 text-wrap ql-editor p-0 {{ $otherClasses }}">{!! nl2br($value) !!}</div>
+        <div class="mb-0 f-14 w-70 text-wrap ql-editor p-0 {{ $otherClasses }}">{!! nl2br($value) !!}</div>
     </div>
 @endif

--- a/resources/views/components/cards/data.blade.php
+++ b/resources/views/components/cards/data.blade.php
@@ -1,12 +1,19 @@
-<div {{ $attributes->merge(['class' => 'card bg-white border-0 b-shadow-4']) }}>
+@props(['customFieldCategories' => null])
+<div {{ $attributes->merge(['class' => 'card bg-white border-0 b-shadow-4 overflow-hidden']) }} style="padding: 0 36px;">
+
     @if ($title)
         <x-cards.card-header>
             {!! $title !!}
 
+            @if ($customFieldCategories)
+                <x-slot name="customFieldCategories">
+                    {!! $customFieldCategories !!}
+                </x-slot>
+            @endif
+
             <x-slot name="action">
                 {!! $action !!}
             </x-slot>
-
         </x-cards.card-header>
     @endif
 
@@ -15,10 +22,7 @@
             {{ $slot }}
         </div>
     @else
-        <div @class([
-            'card-body', 'pt-2' => ($title),
-            $otherClasses
-        ])>
+        <div @class(['card-body', 'pt-2' => $title, $otherClasses])>
             {{ $slot }}
         </div>
     @endif

--- a/resources/views/components/custom-field-category-tabs.blade.php
+++ b/resources/views/components/custom-field-category-tabs.blade.php
@@ -1,0 +1,48 @@
+@props(['customFieldCategories', 'defaultLabel' => 'app.generalInformation'])
+
+@if (isset($customFieldCategories) && count($customFieldCategories) > 0)
+    <div class="flex gap-3">
+        <button type="button"
+            class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-lg hover:bg-blue-700 hover:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+            data-category-id="general" data-active="true">
+            @lang($defaultLabel)
+        </button>
+        @foreach ($customFieldCategories as $category)
+            <button type="button"
+                class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+                data-category-id="{{ $category->id }}">
+                {{ $category->name }}
+            </button>
+        @endforeach
+    </div>
+@endif
+
+
+<script>
+    $(document).ready(function() {
+        // Category tab click handler
+        $('[data-category-id]').on('click', function() {
+            var categoryId = $(this).attr('data-category-id');
+            // Remove highlight from all buttons
+            $('[data-category-id]').removeClass(
+                'active-category bg-blue-600 text-white border-blue-600').addClass(
+                'bg-white text-gray-700 border-gray-300');
+            // Add highlight to the clicked button
+            $(this).addClass('active-category bg-blue-600 text-white border-blue-600').removeClass(
+                'bg-white text-gray-700 border-gray-300');
+            if (categoryId === 'general') {
+                $('#normal-fields-container').show();
+                $('.custom-fields-category-container').hide();
+            } else {
+                $('#normal-fields-container').hide();
+                $('.custom-fields-category-container').hide();
+                $('#custom-fields-category-' + categoryId).show();
+            }
+        });
+        // Default state: highlight 'General Information'
+        $('[data-category-id="general"]').addClass('active-category bg-blue-600 text-white border-blue-600')
+            .removeClass('bg-white text-gray-700 border-gray-300');
+        $('#normal-fields-container').show();
+        $('.custom-fields-category-container').hide();
+    });
+</script>

--- a/resources/views/components/forms/custom-field-show.blade.php
+++ b/resources/views/components/forms/custom-field-show.blade.php
@@ -1,50 +1,59 @@
+@props(['fields', 'model' => null, 'categoryId' => null])
 @if (isset($fields))
     @foreach ($fields as $field)
+        @if (!is_null($categoryId) && $field->custom_field_category_id != $categoryId)
+            @continue
+        @endif
         @if (in_array($field->type, ['text', 'password', 'number']))
-            <x-cards.data-row
-                :label="$field->label"
-                :value="$model->custom_fields_data['field_'.$field->id] ?? '--'">
+            <x-cards.data-row :label="$field->label" :value="($model->custom_fields_data['field_' . $field->id] ?? null) === null || ($model->custom_fields_data['field_' . $field->id] ?? null) === '' ? '--' : $model->custom_fields_data['field_' . $field->id]">
             </x-cards.data-row>
-
         @elseif($field->type == 'textarea')
-            <x-cards.data-row
-                :label="$field->label"
-                html="true"
-                :value="$model->custom_fields_data['field_'.$field->id] ?? '--'">
+            <x-cards.data-row :label="$field->label" html="true" :value="($model->custom_fields_data['field_' . $field->id] ?? null) === null || ($model->custom_fields_data['field_' . $field->id] ?? null) === '' ? '--' : $model->custom_fields_data['field_' . $field->id]">
             </x-cards.data-row>
-
         @elseif($field->type == 'radio')
-            <x-cards.data-row :label="$field->label"
-                              :value="(!is_null($model->custom_fields_data['field_' . $field->id]) ? $model->custom_fields_data['field_' . $field->id] : '--')">
+            <x-cards.data-row :label="$field->label" :value="!is_null($model->custom_fields_data['field_' . $field->id])
+                ? $model->custom_fields_data['field_' . $field->id]
+                : '--'">
             </x-cards.data-row>
-
         @elseif($field->type == 'checkbox')
-            <x-cards.data-row :label="$field->label"
-                              :value="(!is_null($model->custom_fields_data['field_' . $field->id]) ? $model->custom_fields_data['field_' . $field->id] : '--')">
+            <x-cards.data-row :label="$field->label" :value="!is_null($model->custom_fields_data['field_' . $field->id])
+                ? $model->custom_fields_data['field_' . $field->id]
+                : '--'">
             </x-cards.data-row>
-
         @elseif($field->type == 'select')
-            <x-cards.data-row :label="$field->label"
-                              :value="(!is_null($model->custom_fields_data['field_' . $field->id]) && $model->custom_fields_data['field_' . $field->id] != '' ? $field->values[$model->custom_fields_data['field_' . $field->id]] : '--')">
+            <x-cards.data-row :label="$field->label" :value="!is_null($model->custom_fields_data['field_' . $field->id]) &&
+            $model->custom_fields_data['field_' . $field->id] != ''
+                ? $field->values[$model->custom_fields_data['field_' . $field->id]]
+                : '--'">
             </x-cards.data-row>
-
         @elseif($field->type == 'date')
-            <x-cards.data-row :label="$field->label"
-                              :value="(!is_null($model->custom_fields_data['field_' . $field->id]) && $model->custom_fields_data['field_' . $field->id] != '' ? \Carbon\Carbon::parse($model->custom_fields_data['field_' . $field->id])->translatedFormat(company()->date_format) : '--')">
+            <x-cards.data-row :label="$field->label" :value="!is_null($model->custom_fields_data['field_' . $field->id]) &&
+            $model->custom_fields_data['field_' . $field->id] != ''
+                ? \Carbon\Carbon::parse($model->custom_fields_data['field_' . $field->id])->translatedFormat(
+                    company()->date_format,
+                )
+                : '--'">
             </x-cards.data-row>
         @elseif($field->type == 'file')
             @php
                 $fileValue = '--';
-                if(!is_null($model->custom_fields_data['field_'.$field->id]) && $model->custom_fields_data['field_'.$field->id] != ''){
-                    $fileValue = '<a href="'.asset_url_local_s3('custom_fields/' .$model->custom_fields_data['field_'.$field->id]).'" class="text-dark-grey" download>'.__('app.storageSetting.downloadFile').' <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" data-original-title="' . __('app.downloadableFile') .'" data-html="true" data-trigger="hover"></i></a>';
+                if (
+                    !is_null($model->custom_fields_data['field_' . $field->id]) &&
+                    $model->custom_fields_data['field_' . $field->id] != ''
+                ) {
+                    $fileValue =
+                        '<a href="' .
+                        asset_url_local_s3('custom_fields/' . $model->custom_fields_data['field_' . $field->id]) .
+                        '" class="text-dark-grey" download>' .
+                        __('app.storageSetting.downloadFile') .
+                        ' <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="top" data-original-title="' .
+                        __('app.downloadableFile') .
+                        '" data-html="true" data-trigger="hover"></i></a>';
                 }
             @endphp
 
-            <x-cards.data-row
-            :label="$field->label"
-            :value="$fileValue">
+            <x-cards.data-row :label="$field->label" :value="$fileValue">
             </x-cards.data-row>
         @endif
-        {{-- @dd($model->custom_fields_data) --}}
     @endforeach
 @endif

--- a/resources/views/lead-contact/ajax/create.blade.php
+++ b/resources/views/lead-contact/ajax/create.blade.php
@@ -19,22 +19,7 @@
                     <h4 class="mb-0 f-21 font-weight-normal">
                         @lang('modules.leadContact.leadDetails')
                     </h4>
-                    @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
-                        <div class="flex gap-2">
-                            <button type="button"
-                                class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-lg hover:bg-blue-700 hover:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-                                data-category-id="general" data-active="true">
-                                @lang('app.generalInformation')
-                            </button>
-                            @foreach ($customFieldCategories as $category)
-                                <button type="button"
-                                    class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-                                    data-category-id="{{ $category->id }}">
-                                    {{ $category->name }}
-                                </button>
-                            @endforeach
-                        </div>
-                    @endif
+                    <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
                 </div>
 
 
@@ -56,10 +41,14 @@
                         </div>
 
                         <div class="col-lg-4 col-md-6">
-
                             <x-forms.email fieldId="client_email" :fieldLabel="__('app.email')" fieldName="client_email"
                                 :fieldPlaceholder="__('placeholders.email')" :fieldHelp="__('modules.lead.leadEmailInfo')">
                             </x-forms.email>
+                        </div>
+
+                        <div class="col-lg-4 col-md-6">
+                            <x-forms.tel fieldId="mobile" :fieldLabel="__('modules.lead.mobile')" fieldName="mobile"
+                                :fieldPlaceholder="__('placeholders.mobile')"></x-forms.tel>
                         </div>
 
                         @if ($viewLeadSourcesPermission != 'none')
@@ -281,35 +270,6 @@
 
     </div>
 </div>
-
-<script>
-    $(document).ready(function() {
-        // Category tab click handler
-        $('[data-category-id]').on('click', function() {
-            var categoryId = $(this).attr('data-category-id');
-            // Remove highlight from all buttons
-            $('[data-category-id]').removeClass(
-                'active-category bg-blue-600 text-white border-blue-600').addClass(
-                'bg-white text-gray-700 border-gray-300');
-            // Add highlight to the clicked button
-            $(this).addClass('active-category bg-blue-600 text-white border-blue-600').removeClass(
-                'bg-white text-gray-700 border-gray-300');
-            if (categoryId === 'general') {
-                $('#normal-fields-container').show();
-                $('.custom-fields-category-container').hide();
-            } else {
-                $('#normal-fields-container').hide();
-                $('.custom-fields-category-container').hide();
-                $('#custom-fields-category-' + categoryId).show();
-            }
-        });
-        // Default state: highlight 'General Information'
-        $('[data-category-id="general"]').addClass('active-category bg-blue-600 text-white border-blue-600')
-            .removeClass('bg-white text-gray-700 border-gray-300');
-        $('#normal-fields-container').show();
-        $('.custom-fields-category-container').hide();
-    });
-</script>
 
 <script>
     $(document).ready(function() {

--- a/resources/views/lead-contact/ajax/edit.blade.php
+++ b/resources/views/lead-contact/ajax/edit.blade.php
@@ -16,22 +16,7 @@
                     <h4 class="mb-0 f-21 font-weight-normal">
                         @lang('modules.leadContact.leadDetails')
                     </h4>
-                    @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
-                        <div class="flex gap-2">
-                            <button type="button"
-                                class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-lg hover:bg-blue-700 hover:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-                                data-category-id="general" data-active="true">
-                                @lang('app.generalInformation')
-                            </button>
-                            @foreach ($customFieldCategories as $category)
-                                <button type="button"
-                                    class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-                                    data-category-id="{{ $category->id }}">
-                                    {{ $category->name }}
-                                </button>
-                            @endforeach
-                        </div>
-                    @endif
+                    <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
                 </div>
 
                 <div id="normal-fields-container">
@@ -196,37 +181,6 @@
 
     </div>
 </div>
-
-
-<script>
-    $(document).ready(function() {
-        // Category tab click handler
-        $('[data-category-id]').on('click', function() {
-            var categoryId = $(this).attr('data-category-id');
-            // Remove highlight from all buttons
-            $('[data-category-id]').removeClass(
-                'active-category bg-blue-600 text-white border-blue-600').addClass(
-                'bg-white text-gray-700 border-gray-300');
-            // Add highlight to the clicked button
-            $(this).addClass('active-category bg-blue-600 text-white border-blue-600').removeClass(
-                'bg-white text-gray-700 border-gray-300');
-            if (categoryId === 'general') {
-                $('#normal-fields-container').show();
-                $('.custom-fields-category-container').hide();
-            } else {
-                $('#normal-fields-container').hide();
-                $('.custom-fields-category-container').hide();
-                $('#custom-fields-category-' + categoryId).show();
-            }
-        });
-        // Default state: highlight 'General Information'
-        $('[data-category-id="general"]').addClass('active-category bg-blue-600 text-white border-blue-600')
-            .removeClass('bg-white text-gray-700 border-gray-300');
-        $('#normal-fields-container').show();
-        $('.custom-fields-category-container').hide();
-    });
-</script>
-
 
 <script>
     $(document).ready(function() {

--- a/resources/views/lead-contact/ajax/profile.blade.php
+++ b/resources/views/lead-contact/ajax/profile.blade.php
@@ -3,12 +3,15 @@
     <!--  USER CARDS START -->
     <div class="col-xl-12 col-lg-12 col-md-12 mb-4 mb-xl-0 mb-lg-4 mb-md-0">
 
-        <x-cards.data :title="__('modules.client.profileInfo')">
+        <x-cards.data :title="__('modules.leadContact.leadDetails')">
+            <x-slot name="customFieldCategories">
+                <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
+            </x-slot>
 
             <x-slot name="action">
                 <div class="dropdown">
-                    <button class="btn f-14 px-0 py-0 text-dark-grey dropdown-toggle" type="button"
-                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <button class="btn f-14 px-0 py-0 text-dark-grey dropdown-toggle" type="button" data-toggle="dropdown"
+                        aria-haspopup="true" aria-expanded="false">
                         <i class="fa fa-ellipsis-h"></i>
                     </button>
 
@@ -16,82 +19,96 @@
                         aria-labelledby="dropdownMenuLink" tabindex="0">
 
                         @if (
-                            $editLeadPermission == 'all'
-                            || $editLeadPermission == 'both' && (user()->id == $leadContact->added_by || user()->id == $leadContact->lead_owner)
-                            || ($editLeadPermission == 'owned' && user()->id == $leadContact->lead_owner )
-                            || ($editLeadPermission == 'added' && user()->id == $leadContact->added_by))
-                        <a class="dropdown-item openRightModal"
-                            href="{{ route('lead-contact.edit', $leadContact->id) }}">@lang('app.edit')</a>
+                            $editLeadPermission == 'all' ||
+                                ($editLeadPermission == 'both' &&
+                                    (user()->id == $leadContact->added_by || user()->id == $leadContact->lead_owner)) ||
+                                ($editLeadPermission == 'owned' && user()->id == $leadContact->lead_owner) ||
+                                ($editLeadPermission == 'added' && user()->id == $leadContact->added_by))
+                            <a class="dropdown-item openRightModal"
+                                href="{{ route('lead-contact.edit', $leadContact->id) }}">@lang('app.edit')</a>
                         @endif
 
                         @if (
-                            $deleteLeadPermission == 'all'
-                            || ($deleteLeadPermission == 'added' && user()->id == $leadContact->added_by)
-                            || ($deleteLeadPermission == 'owned' && user()->id == $leadContact->lead_owner)
-                            || ($deleteLeadPermission == 'both' && user()->id == $leadContact->added_by
-                                    || user()->id == $leadContact->lead_owner))
-                            <a class="dropdown-item delete-table-row" href="javascript:;" data-id="{{ $leadContact->id }}">
-                                    @lang('app.delete')
-                                </a>
+                            $deleteLeadPermission == 'all' ||
+                                ($deleteLeadPermission == 'added' && user()->id == $leadContact->added_by) ||
+                                ($deleteLeadPermission == 'owned' && user()->id == $leadContact->lead_owner) ||
+                                (($deleteLeadPermission == 'both' && user()->id == $leadContact->added_by) ||
+                                    user()->id == $leadContact->lead_owner))
+                            <a class="dropdown-item delete-table-row" href="javascript:;"
+                                data-id="{{ $leadContact->id }}">
+                                @lang('app.delete')
+                            </a>
                         @endif
 
                         @if ($leadContact->client_id == null || $leadContact->client_id == '')
-                            <a class="dropdown-item" href="{{route('clients.create') . '?lead=' . $leadContact->id }}">
+                            <a class="dropdown-item" href="{{ route('clients.create') . '?lead=' . $leadContact->id }}">
                                 @lang('modules.lead.changeToClient')
                             </a>
                         @endif
                     </div>
                 </div>
             </x-slot>
-            <x-cards.data-row :label="__('app.name')" :value="$leadContact->client_name_salutation ?? '--'" />
 
-            <x-cards.data-row :label="__('app.email')" :value="$leadContact->client_email ?? '--'" />
+            <div id="normal-fields-container" class="row">
+                <x-cards.data-row :label="__('app.name')" :value="$leadContact->client_name_salutation ?? '--'" />
 
-            @if(!is_null($leadContact->added_by))
-                <div class="col-12 px-0 pb-3 d-block d-lg-flex d-md-flex">
-                    <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">
-                        @lang('app.addedBy')</p>
-                    <p class="mb-0 text-dark-grey f-14 ">
-                        <x-employee :user="$leadContact->addedBy" />
-                    </p>
-                </div>
-            @endif
+                <x-cards.data-row :label="__('app.email')" :value="$leadContact->client_email ?? '--'" />
 
-            @if(!is_null($leadContact->lead_owner))
-                <div class="col-12 px-0 pb-3 d-block d-lg-flex d-md-flex">
-                    <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">
-                        @lang('app.owner')</p>
-                    <p class="mb-0 text-dark-grey f-14 ">
-                        <x-employee :user="$leadContact->leadOwner" />
-                    </p>
-                </div>
-            @else
-            <x-cards.data-row :label="__('app.owner')" :value="'--'" />
-            @endif
+                @if (!is_null($leadContact->added_by))
+                    <div class="col-6 px-0 pb-3 d-block d-lg-flex d-md-flex">
+                        <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">
+                            @lang('app.addedBy')</p>
+                        <p class="mb-0 text-dark-grey f-14 ">
+                            <x-employee :user="$leadContact->addedBy" />
+                        </p>
+                    </div>
+                @endif
 
-            <x-cards.data-row :label="__('modules.lead.source')" :value="$leadContact->leadSource ? $leadContact->leadSource->type : '--'" />
+                @if (!is_null($leadContact->lead_owner))
+                    <div class="col-6 px-0 pb-3 d-block d-lg-flex d-md-flex">
+                        <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">
+                            @lang('app.owner')</p>
+                        <p class="mb-0 text-dark-grey f-14 ">
+                            <x-employee :user="$leadContact->leadOwner" />
+                        </p>
+                    </div>
+                @else
+                    <x-cards.data-row :label="__('app.owner')" :value="'--'" />
+                @endif
 
-            <x-cards.data-row :label="__('modules.lead.companyName')" :value="!empty($leadContact->company_name) ? $leadContact->company_name : '--'" />
+                <x-cards.data-row :label="__('modules.lead.source')" :value="$leadContact->leadSource ? $leadContact->leadSource->type : '--'" />
 
-            <x-cards.data-row :label="__('modules.lead.website')" :value="$leadContact->website ?? '--'" />
+                <x-cards.data-row :label="__('modules.lead.companyName')" :value="!empty($leadContact->company_name) ? $leadContact->company_name : '--'" />
 
-            <x-cards.data-row :label="__('modules.lead.mobile')" :value="$leadContact->mobile ?? '--'" />
+                <x-cards.data-row :label="__('modules.lead.website')" :value="$leadContact->website ?? '--'" />
 
-            <x-cards.data-row :label="__('modules.client.officePhoneNumber')" :value="$leadContact->office ?? '--'" />
+                <x-cards.data-row :label="__('modules.lead.mobile')" :value="$leadContact->mobile ?? '--'" />
 
-            <x-cards.data-row :label="__('app.country')" :value="$leadContact->country ?? '--'" />
+                <x-cards.data-row :label="__('modules.client.officePhoneNumber')" :value="$leadContact->office ?? '--'" />
 
-            <x-cards.data-row :label="__('modules.stripeCustomerAddress.state')" :value="$leadContact->state ?? '--'" />
+                <x-cards.data-row :label="__('app.country')" :value="$leadContact->country ?? '--'" />
 
-            <x-cards.data-row :label="__('modules.stripeCustomerAddress.city')" :value="$leadContact->city ?? '--'" />
+                <x-cards.data-row :label="__('modules.stripeCustomerAddress.state')" :value="$leadContact->state ?? '--'" />
 
-            <x-cards.data-row :label="__('modules.stripeCustomerAddress.postalCode')" :value="$leadContact->postal_code ?? '--'" />
+                <x-cards.data-row :label="__('modules.stripeCustomerAddress.city')" :value="$leadContact->city ?? '--'" />
 
-            <x-cards.data-row :label="__('modules.lead.address')" :value="$leadContact->address ?? '--'" />
+                <x-cards.data-row :label="__('modules.stripeCustomerAddress.postalCode')" :value="$leadContact->postal_code ?? '--'" />
+
+                <x-cards.data-row :label="__('modules.lead.address')" :value="$leadContact->address ?? '--'" />
+            </div>
 
             {{-- Custom fields data --}}
-            <x-forms.custom-field-show :fields="$fields" :model="$leadContact"></x-forms.custom-field-show>
-
+            <div id="custom-fields-category-container">
+                @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
+                    @foreach ($customFieldCategories as $category)
+                        <div class="row custom-fields-category-container"
+                            id="custom-fields-category-{{ $category->id }}" style="display: none;">
+                            <x-forms.custom-field-show :fields="$fields" :model="$leadContact"
+                                :categoryId="$category->id"></x-forms.custom-field-show>
+                        </div>
+                    @endforeach
+                @endif
+            </div>
         </x-cards.data>
     </div>
     <!--  USER CARDS END -->

--- a/resources/views/leads/ajax/profile.blade.php
+++ b/resources/views/leads/ajax/profile.blade.php
@@ -5,6 +5,10 @@
 
         <x-cards.data :title="__('modules.deal.dealInfo')">
 
+            <x-slot name="customFieldCategories">
+                <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
+            </x-slot>
+            
             <x-slot name="action">
                 <div class="dropdown">
                     <button class="btn f-14 px-0 py-0 text-dark-grey dropdown-toggle" type="button"


### PR DESCRIPTION
Extracted custom field category tab UI into a reusable Blade component and updated views to use it for lead contact and lead profile pages. Refactored controller logic to centralize custom field category retrieval. Improved layout and responsiveness of card components and data rows, and enhanced custom field display to support category filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a tabbed interface for custom field categories, allowing users to easily switch between general information and categorized custom fields in lead and deal profiles.
  * Added support for a new telephone input field in the lead contact creation form.

* **Refactor**
  * Replaced manual tab rendering and related scripts with a reusable component for custom field category tabs, streamlining the user interface.
  * Improved layout and grouping of lead details for better readability and organization.

* **Style**
  * Updated several components to use Tailwind CSS classes for enhanced visual consistency and responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->