### PR TITLE
Add custom field category tabs to deal forms and views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Language Support**:
     - Added translations for "Category", "Add Category", "Edit Category" in English
     - Consistent with existing localization patterns
+- **Leads Board Pipeline Display**: Enhanced pipeline heading to show current selected pipeline
+  - **Dynamic Pipeline Heading**: Updated leads board to display the currently selected pipeline name instead of all pipelines
+  - **Controller Enhancement**: Modified `LeadBoardController` to determine and pass current pipeline name to view
+  - **View Updates**: Updated `leads/board/index.blade.php` to display selected pipeline name in heading
+  - **JavaScript Integration**: Added `updatePipelineHeading()` function to dynamically update heading when pipeline filter changes
+  - **User Experience**: Improved clarity by showing specific pipeline name rather than generic "pipelines" text
+- **Deals Table Pipeline Display**: Enhanced pipeline heading to show current selected pipeline in the deals table view
+  - **Dynamic Pipeline Heading**: Updated deals table view to display the currently selected pipeline name instead of all pipelines
+  - **Controller Enhancement**: Modified `DealController` to determine and pass current pipeline name to view
+  - **View Updates**: Updated `leads/index.blade.php` to display selected pipeline name in heading
+  - **JavaScript Integration**: Added `updatePipelineHeading()` function to dynamically update heading when pipeline filter changes
+  - **User Experience**: Improved clarity by showing specific pipeline name rather than generic "pipelines" text
 
 ## [Current State - 2024] - Initial Documentation
 

--- a/app/Http/Controllers/LeadBoardController.php
+++ b/app/Http/Controllers/LeadBoardController.php
@@ -389,6 +389,17 @@ class LeadBoardController extends AccountBaseController
 
         $this->leads = Deal::get();
 
+        // Determine current pipeline name for display
+        $currentPipelineName = $this->defaultPipeline->name;
+        if (request()->has('pipeline') && request('pipeline') != 'all') {
+            $selectedPipeline = $this->pipelines->find(request('pipeline'));
+            if ($selectedPipeline) {
+                $currentPipelineName = $selectedPipeline->name;
+            }
+        }
+
+        $this->data['currentPipelineName'] = $currentPipelineName;
+
         return view('leads.board.index', $this->data);
     }
 

--- a/resources/views/components/custom-field-category-tabs.blade.php
+++ b/resources/views/components/custom-field-category-tabs.blade.php
@@ -1,7 +1,7 @@
 @props(['customFieldCategories', 'defaultLabel' => 'app.generalInformation'])
 
 @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
-    <div class="flex gap-3">
+    <div class="flex flex-wrap gap-3">
         <button type="button"
             class="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-lg hover:bg-blue-700 hover:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
             data-category-id="general" data-active="true">
@@ -9,7 +9,7 @@
         </button>
         @foreach ($customFieldCategories as $category)
             <button type="button"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+                class="px-4 py-2 text-sm font-medium whitespace-nowrap text-gray-700 bg-white border border-gray-300 rounded-lg hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
                 data-category-id="{{ $category->id }}">
                 {{ $category->name }}
             </button>

--- a/resources/views/leads/ajax/create.blade.php
+++ b/resources/views/leads/ajax/create.blade.php
@@ -15,59 +15,57 @@
     <div class="col-sm-12">
         <x-form id="save-lead-data-form">
             <div class="add-client bg-white rounded">
-                <h4 class="mb-0 p-20 f-21 font-weight-normal  border-bottom-grey">
-                    @lang('modules.deal.dealDetails')</h4>
-                <div class="row p-20">
+                <div class="flex justify-between items-center p-4 border-b border-gray-200">
+                    <h4 class="mb-0 f-21 font-weight-normal">
+                        @lang('modules.deal.dealDetails')
+                    </h4>
+                    <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
+                </div>
+
+                <div id="normal-fields-container" class="row p-20">
                     <div class="col-lg-4 ">
-                        <x-forms.select fieldId="lead_contact" :fieldLabel="__('modules.leadContact.leadContacts')"
-                                        fieldName="lead_contact" fieldRequired="true" search="true">
+                        <x-forms.select fieldId="lead_contact" :fieldLabel="__('modules.leadContact.leadContacts')" fieldName="lead_contact"
+                            fieldRequired="true" search="true">
                             <option value="">--</option>
                             @foreach ($leadContacts as $leadContact)
-                                <option
-                                    @selected(!is_null($contactID) && $contactID == $leadContact->id)  value="{{ $leadContact->id }}">
+                                <option @selected(!is_null($contactID) && $contactID == $leadContact->id) value="{{ $leadContact->id }}">
                                     {{ $leadContact->client_name_salutation }}</option>
                             @endforeach
                         </x-forms.select>
                     </div>
                     <div class="col-lg-4 col-md-6">
-                        <x-forms.text :fieldLabel="__('modules.deal.dealName')" fieldName="name"
-                                      fieldId="name" :fieldPlaceholder="__('placeholders.name')" fieldRequired="true"
-                                      :popover="__('modules.deal.dealnameInfo')"/>
+                        <x-forms.text :fieldLabel="__('modules.deal.dealName')" fieldName="name" fieldId="name" :fieldPlaceholder="__('placeholders.name')"
+                            fieldRequired="true" :popover="__('modules.deal.dealnameInfo')" />
                     </div>
                     <div class="col-lg-4">
-                        <x-forms.select fieldId="pipelineData" :fieldLabel="__('modules.deal.pipeline')"
-                                        fieldName="pipeline" fieldRequired="true"
-                                        :popover="__('modules.lead.pipelineInfo')">
+                        <x-forms.select fieldId="pipelineData" :fieldLabel="__('modules.deal.pipeline')" fieldName="pipeline"
+                            fieldRequired="true" :popover="__('modules.lead.pipelineInfo')">
                             @foreach ($leadPipelines as $pipeline)
-                                <option
-                                    @selected(!is_null($stage) && $stage->lead_pipeline_id == $pipeline->id)  value="{{ $pipeline->id }}">
+                                <option @selected(!is_null($stage) && $stage->lead_pipeline_id == $pipeline->id) value="{{ $pipeline->id }}">
                                     {{ $pipeline->name }}</option>
                             @endforeach
                         </x-forms.select>
                     </div>
                     <div class="col-lg-4 mt-2">
-                        <x-forms.select fieldId="stages" :fieldLabel="__('modules.deal.stages')" fieldName="stage_id"
-                                        fieldRequired="true">
+                        <x-forms.select fieldId="stages" :fieldLabel="__('modules.deal.stages')" fieldName="stage_id" fieldRequired="true">
 
                         </x-forms.select>
                     </div>
                     <div class="col-lg-4 col-md-6">
-                        <x-forms.label class="my-3" fieldId="value" :fieldLabel="__('modules.deal.dealValue')"
-                                       fieldRequired="true">
+                        <x-forms.label class="my-3" fieldId="value" :fieldLabel="__('modules.deal.dealValue')" fieldRequired="true">
                         </x-forms.label>
                         <x-forms.input-group>
                             <x-slot name="prepend">
-                                <span
-                                    class="input-group-text f-14">{{ company()->currency->currency_code }} ({{ company()->currency->currency_symbol }})</span>
+                                <span class="input-group-text f-14">{{ company()->currency->currency_code }}
+                                    ({{ company()->currency->currency_symbol }})</span>
                             </x-slot>
-                            <input type="number" name="value" id="value" class="form-control height-35 f-14" value="0"/>
+                            <input type="number" name="value" id="value" class="form-control height-35 f-14"
+                                value="0" />
                         </x-forms.input-group>
                     </div>
                     <div class="col-md-5 col-lg-4 dueDateBox mt-1">
-                        <x-forms.datepicker fieldId="close_date" fieldRequired="true"
-                                            :fieldLabel="__('modules.deal.closeDate')"
-                                            fieldName="close_date" :fieldPlaceholder="__('placeholders.date')"
-                                            :fieldValue="( now(company()->timezone)->addDays(30)->translatedFormat(company()->date_format))"/>
+                        <x-forms.datepicker fieldId="close_date" fieldRequired="true" :fieldLabel="__('modules.deal.closeDate')"
+                            fieldName="close_date" :fieldPlaceholder="__('placeholders.date')" :fieldValue="now(company()->timezone)->addDays(30)->translatedFormat(company()->date_format)" />
                     </div>
                     @if ($viewLeadCategoryPermission != 'none')
                         <div class="col-lg-4 col-md-6">
@@ -86,7 +84,8 @@
                                     <x-slot name="append">
                                         <button type="button"
                                             class="btn btn-outline-secondary border-grey add-lead-category"
-                                            data-toggle="tooltip" data-original-title="{{ __('app.add').' '.__('modules.lead.leadCategory') }}">
+                                            data-toggle="tooltip"
+                                            data-original-title="{{ __('app.add') . ' ' . __('modules.lead.leadCategory') }}">
                                             @lang('app.add')</button>
                                     </x-slot>
                                 @endif
@@ -99,16 +98,16 @@
                             </x-forms.label>
                             <x-forms.input-group>
                                 <select class="form-control select-picker" name="agent_id" id="deal_agent_id"
-                                        data-live-search="true">
+                                    data-live-search="true">
                                     <option value="">--</option>
                                 </select>
 
                                 @if ($addLeadAgentPermission == 'all' || $addLeadAgentPermission == 'added')
                                     <x-slot name="append">
                                         <button type="button"
-                                                class="btn btn-outline-secondary border-grey add-lead-agent"
-                                                data-toggle="tooltip"
-                                                data-original-title="{{ __('app.add').'  '.__('app.new').' '.__('modules.tickets.agents') }}">@lang('app.add')</button>
+                                            class="btn btn-outline-secondary border-grey add-lead-agent"
+                                            data-toggle="tooltip"
+                                            data-original-title="{{ __('app.add') . '  ' . __('app.new') . ' ' . __('modules.tickets.agents') }}">@lang('app.add')</button>
                                     </x-slot>
                                 @endif
                             </x-forms.input-group>
@@ -117,50 +116,57 @@
                         <input type="hidden" value="{{ $myAgentId }}" name="agent_id">
                     @endif
 
-                    @if(in_array('products', user_modules()) || in_array('purchase', user_modules()))
+                    @if (in_array('products', user_modules()) || in_array('purchase', user_modules()))
                         <div class="col-lg-4 mt-3">
                             <div class="form-group">
                                 <x-forms.label fieldId="selectProduct" :fieldLabel="__('app.menu.products')">
                                 </x-forms.label>
                                 <x-forms.input-group>
                                     <select class="form-control select-picker" data-live-search="true" data-size="8"
-                                            name="product_id[]" multiple id="add-products"
-                                            title="{{ __('app.menu.selectProduct') }}">
+                                        name="product_id[]" multiple id="add-products"
+                                        title="{{ __('app.menu.selectProduct') }}">
                                         @foreach ($products as $item)
                                             <option data-content="{{ $item->name }}" value="{{ $item->id }}">
                                                 {{ $item->name }}</option>
                                         @endforeach
                                     </select>
                                     {{-- @if ($addProductPermission == 'all' || $addProductPermission == 'added')
-                                        <x-slot name="append">
-                                            <a href="{{ route('products.create') }}" data-redirect-url="no"
-                                               class="btn btn-outline-secondary border-grey openRightModal"
-                                               data-toggle="tooltip"
-                                               data-original-title="{{ __('app.add').' '.__('modules.dashboard.newproduct') }}">@lang('app.add')</a>
-                                        </x-slot>
-                                    @endif --}}
+                                            <x-slot name="append">
+                                                <a href="{{ route('products.create') }}" data-redirect-url="no"
+                                                   class="btn btn-outline-secondary border-grey openRightModal"
+                                                   data-toggle="tooltip"
+                                                   data-original-title="{{ __('app.add').' '.__('modules.dashboard.newproduct') }}">@lang('app.add')</a>
+                                            </x-slot>
+                                        @endif --}}
                                 </x-forms.input-group>
                             </div>
                         </div>
                     @endif
 
                     <div class="col-lg-4 col-md-6">
-                        <x-forms.select fieldId="deal_watcher" :fieldLabel="__('app.dealWatcher')"
-                                        fieldName="deal_watcher">
+                        <x-forms.select fieldId="deal_watcher" :fieldLabel="__('app.dealWatcher')" fieldName="deal_watcher">
                             <option value="">--</option>
                             @foreach ($employees as $item)
-                                <x-user-option :user="$item" :selected="(user()->id == $item->id)"/>
+                                <x-user-option :user="$item" :selected="user()->id == $item->id" />
                             @endforeach
                         </x-forms.select>
                     </div>
-
-                    <x-forms.custom-field :fields="$fields" class="col-md-12"></x-forms.custom-field>
                 </div>
+
+                @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
+                    @foreach ($customFieldCategories as $category)
+                        <div class="custom-fields-category-container" id="custom-fields-category-{{ $category->id }}"
+                            style="display: none;">
+                            <x-forms.custom-field :fields="$fields" :categoryId="$category->id" />
+                        </div>
+                    @endforeach
+                @endif
+
                 <x-form-actions>
                     <x-forms.button-primary id="save-lead-form" class="mr-3" icon="check">@lang('app.save')
                     </x-forms.button-primary>
                     <x-forms.button-secondary class="mr-3" id="save-more-lead-form"
-                                              icon="check-double">@lang('app.saveAddMore')
+                        icon="check-double">@lang('app.saveAddMore')
                     </x-forms.button-secondary>
                     <x-forms.button-cancel :link="route('lead-contact.index')" class="border-0">@lang('app.cancel')
                     </x-forms.button-cancel>
@@ -173,26 +179,22 @@
 </div>
 
 <script>
-
-    $(document).ready(function () {
+    $(document).ready(function() {
         var id = $('#category_id').val();
-        if(id != '')
-        {
+        if (id != '') {
             getAgents($('#category_id').val());
         }
 
-        function getAgents(categoryId){
-            var url = "{{ route('deals.get_agents', ':id')}}";
+        function getAgents(categoryId) {
+            var url = "{{ route('deals.get_agents', ':id') }}";
             url = url.replace(':id', categoryId);
             $.easyAjax({
                 url: url,
                 type: "GET",
-                success: function(response)
-                {
+                success: function(response) {
                     var options = [];
                     var rData = [];
-                    if($.isArray(response.data))
-                    {
+                    if ($.isArray(response.data)) {
                         rData = response.data;
                         $.each(rData, function(index, value) {
                             var selectData = '';
@@ -201,9 +203,7 @@
 
                         $('#deal_agent_id').html('<option value="">--</option>' + options);
 
-                    }
-                    else
-                    {
+                    } else {
                         $('#deal_agent_id').html(response.data);
                     }
 
@@ -212,7 +212,7 @@
             });
         }
 
-        $('#close_date').each(function (ind, el) {
+        $('#close_date').each(function(ind, el) {
             datepicker(el, {
                 position: 'bl',
                 ...datepickerConfig
@@ -221,10 +221,9 @@
 
         getStages($('#pipelineData').val());
 
-        $('#category_id').change(function(){
+        $('#category_id').change(function() {
             var id = $(this).val();
-            if(id != '')
-            {
+            if (id != '') {
                 getAgents(id);
             }
         });
@@ -235,23 +234,24 @@
             $.easyAjax({
                 url: url,
                 type: "GET",
-                success: function (response) {
+                success: function(response) {
                     if (response.status == 'success') {
                         var options = [];
                         var rData = [];
                         rData = response.data;
-                        $.each(rData, function (index, value) {
+                        $.each(rData, function(index, value) {
                             var seleted = '';
                             var stageID = 0;
-                            @if(!is_null($stage))
+                            @if (!is_null($stage))
                                 stageID = {{ $stage->id }};
 
-                            if (stageID == value.id) {
-                                seleted = 'selected';
-                            }
+                                if (stageID == value.id) {
+                                    seleted = 'selected';
+                                }
                             @endif
                             var selectData = '';
-                            selectData = `<option data-content="<i class='fa fa-circle' style='color: ${value.label_color}'></i> ${value.name} " value="${value.id}"> ${value.name}</option>`;
+                            selectData =
+                                `<option data-content="<i class='fa fa-circle' style='color: ${value.label_color}'></i> ${value.name} " value="${value.id}"> ${value.name}</option>`;
                             options.push(selectData);
                         });
                         $('#stages').html(options);
@@ -262,12 +262,12 @@
         }
 
         // GET STAGES
-        $('#pipelineData').on("change", function (e) {
+        $('#pipelineData').on("change", function(e) {
             let pipelineId = $(this).val();
             getStages(pipelineId)
         });
 
-        $('#save-more-lead-form').click(function () {
+        $('#save-more-lead-form').click(function() {
             $('#add_more').val(true);
             const url = "{{ route('deals.store') }}?add_more=true";
             var data = $('#save-lead-data-form').serialize() + '&add_more=true';
@@ -275,7 +275,7 @@
 
         });
 
-        $('#save-lead-form').click(function () {
+        $('#save-lead-form').click(function() {
             const url = "{{ route('deals.store') }}";
             var data = $('#save-lead-data-form').serialize();
             saveLead(data, url, "#save-lead-form");
@@ -292,7 +292,7 @@
                 blockUI: true,
                 buttonSelector: buttonSelector,
                 data: data,
-                success: function (response) {
+                success: function(response) {
                     if (response.add_more == true) {
 
                         var right_modal_content = $.trim($(RIGHT_MODAL_CONTENT).html());
@@ -319,33 +319,30 @@
 
         }
 
-        $('body').on('click', '.add-lead-agent', function () {
+        $('body').on('click', '.add-lead-agent', function() {
             var categoryId = $('#category_id').val();
-            var url = "{{ route('lead-agent-settings.create').'?categoryId='}}"+categoryId;
+            var url = "{{ route('lead-agent-settings.create') . '?categoryId=' }}" + categoryId;
             $(MODAL_LG + ' ' + MODAL_HEADING).html('...');
             $.ajaxModal(MODAL_LG, url);
         });
 
-        $('body').on('click', '.add-lead-source', function () {
+        $('body').on('click', '.add-lead-source', function() {
             var url = '{{ route('lead-source-settings.create') }}';
             $(MODAL_LG + ' ' + MODAL_HEADING).html('...');
             $.ajaxModal(MODAL_LG, url);
         });
 
-        $('body').on('click', '.add-lead-category', function () {
+        $('body').on('click', '.add-lead-category', function() {
             var url = '{{ route('leadCategory.create') }}';
             $(MODAL_LG + ' ' + MODAL_HEADING).html('...');
             $.ajaxModal(MODAL_LG, url);
         });
 
-        $('.toggle-other-details').click(function () {
+        $('.toggle-other-details').click(function() {
             $(this).find('svg').toggleClass('fa-chevron-down fa-chevron-up');
             $('#other-details').toggleClass('d-none');
         });
 
         init(RIGHT_MODAL);
     });
-
-
-
 </script>

--- a/resources/views/leads/ajax/edit.blade.php
+++ b/resources/views/leads/ajax/edit.blade.php
@@ -1,13 +1,12 @@
 @php
-$viewLeadAgentPermission = user()->permission('view_lead_agents');
-$viewLeadCategoryPermission = user()->permission('view_lead_category');
-$viewLeadSourcesPermission = user()->permission('view_lead_sources');
-$addLeadAgentPermission = user()->permission('add_lead_agent');
-$addLeadSourcesPermission = user()->permission('add_lead_sources');
-$addLeadCategoryPermission = user()->permission('add_lead_category');
-$addProductPermission = user()->permission('add_product');
-$changeDealStagesPermission = user()->permission('change_deal_stages');
-
+    $viewLeadAgentPermission = user()->permission('view_lead_agents');
+    $viewLeadCategoryPermission = user()->permission('view_lead_category');
+    $viewLeadSourcesPermission = user()->permission('view_lead_sources');
+    $addLeadAgentPermission = user()->permission('add_lead_agent');
+    $addLeadSourcesPermission = user()->permission('add_lead_sources');
+    $addLeadCategoryPermission = user()->permission('add_lead_category');
+    $addProductPermission = user()->permission('add_product');
+    $changeDealStagesPermission = user()->permission('change_deal_stages');
 @endphp
 
 <link rel="stylesheet" href="{{ asset('vendor/css/dropzone.min.css') }}">
@@ -16,15 +15,19 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
     <div class="col-sm-12">
         <x-form id="save-lead-data-form" method="PUT">
             <div class="add-client bg-white rounded">
-                <h4 class="mb-0 p-20 f-21 font-weight-normal  border-bottom-grey">
-                    @lang('modules.deal.dealDetails')</h4>
+                <div class="flex justify-between items-center p-4 border-b border-gray-200">
+                    <h4 class="mb-0 f-21 font-weight-normal">
+                        @lang('modules.deal.dealDetails')
+                    </h4>
+                    <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
+                </div>
 
-                <div class="row p-20">
+                <div id="normal-fields-container" class="row p-20">
                     {{-- <div class="col-lg-4 ">
                         <x-forms.select fieldId="lead_contact" :fieldLabel="__('modules.leadContact.leadContacts')" fieldName="lead_contact" fieldRequired="true">
                             <option value="">--</option>
                             @foreach ($leadContacts as $leadContact)
-                                <option @if($leadContact->id == $deal->lead_id) selected @endif value="{{ $leadContact->id }}">
+                                <option @if ($leadContact->id == $deal->lead_id) selected @endif value="{{ $leadContact->id }}">
                                     {{ $leadContact->client_name_salutation }}</option>
                             @endforeach
                         </x-forms.select>
@@ -32,13 +35,13 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
 
 
                     <div class="col-lg-4 col-md-6">
-                        <x-forms.text :fieldLabel="__('app.name')" fieldName="name"
-                            fieldId="name" fieldPlaceholder="" fieldRequired="true"
-                            :fieldValue="$deal->name" />
+                        <x-forms.text :fieldLabel="__('app.name')" fieldName="name" fieldId="name" fieldPlaceholder=""
+                            fieldRequired="true" :fieldValue="$deal->name" />
                     </div>
 
                     <div class="col-lg-4">
-                        <x-forms.select fieldId="editPipeline" :fieldLabel="__('modules.deal.pipeline')" fieldName="pipeline" fieldRequired="true">
+                        <x-forms.select fieldId="editPipeline" :fieldLabel="__('modules.deal.pipeline')" fieldName="pipeline"
+                            fieldRequired="true">
                             @foreach ($leadPipelines as $pipeline)
                                 <option @selected($pipeline->id == $deal->lead_pipeline_id) value="{{ $pipeline->id }}">
                                     {{ $pipeline->name }}</option>
@@ -46,9 +49,10 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
                         </x-forms.select>
                     </div>
                     <div class="col-lg-4">
-                        <x-forms.select fieldId="stages" :fieldLabel="__('modules.deal.stages')" fieldName="stage_id" fieldRequired="true" changeDealStage="{{$changeDealStagesPermission}}">
+                        <x-forms.select fieldId="stages" :fieldLabel="__('modules.deal.stages')" fieldName="stage_id" fieldRequired="true"
+                            changeDealStage="{{ $changeDealStagesPermission }}">
                             @foreach ($stages as $stage)
-                                <option @selected($stage->id == $deal->pipeline_stage_id) value="{{ $stage->id }}"   >
+                                <option @selected($stage->id == $deal->pipeline_stage_id) value="{{ $stage->id }}">
                                     {{ $stage->name }}</option>
                             @endforeach
                         </x-forms.select>
@@ -63,7 +67,9 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
                                     data-live-search="true">
                                     <option value="">--</option>
                                     @forelse($categories as $category)
-                                        <option value="{{ $category->id }}" @if ($deal->category_id == $category->id) selected @endif>{{ $category->category_name }}</option>
+                                        <option value="{{ $category->id }}"
+                                            @if ($deal->category_id == $category->id) selected @endif>
+                                            {{ $category->category_name }}</option>
                                     @empty
                                         <option value="">@lang('messages.noCategoryAdded')</option>
                                     @endforelse
@@ -73,7 +79,8 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
                                     <x-slot name="append">
                                         <button type="button"
                                             class="btn btn-outline-secondary border-grey add-lead-category"
-                                            data-toggle="tooltip" data-original-title="{{ __('app.add').' '.__('modules.lead.leadCategory') }}">@lang('app.add')</button>
+                                            data-toggle="tooltip"
+                                            data-original-title="{{ __('app.add') . ' ' . __('modules.lead.leadCategory') }}">@lang('app.add')</button>
                                     </x-slot>
                                 @endif
                             </x-forms.input-group>
@@ -94,7 +101,8 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
                                     <x-slot name="append">
                                         <button type="button"
                                             class="btn btn-outline-secondary border-grey add-lead-agent"
-                                            data-toggle="tooltip" data-original-title="{{ __('app.add').'  '.__('app.new').' '.__('modules.tickets.agents') }}">@lang('app.add')</button>
+                                            data-toggle="tooltip"
+                                            data-original-title="{{ __('app.add') . '  ' . __('app.new') . ' ' . __('modules.tickets.agents') }}">@lang('app.add')</button>
                                     </x-slot>
                                 @endif
                             </x-forms.input-group>
@@ -107,26 +115,32 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
                         <x-forms.input-group>
                             <x-slot name="prepend">
                                 <span
-                                    class="input-group-text f-14">{{!is_null($deal->currency_id) ? $deal->currency->currency_code : company()->currency->currency_code}} ( {{ !is_null($deal->currency_id) ? $deal->currency->currency_symbol : company()->currency->currency_symbol }} )</span>
+                                    class="input-group-text f-14">{{ !is_null($deal->currency_id) ? $deal->currency->currency_code : company()->currency->currency_code }}
+                                    (
+                                    {{ !is_null($deal->currency_id) ? $deal->currency->currency_symbol : company()->currency->currency_symbol }}
+                                    )</span>
                             </x-slot>
-                            <input type="number" name="value" id="value" class="form-control height-35 f-14" value="{{$deal->value}}"/>
+                            <input type="number" name="value" id="value" class="form-control height-35 f-14"
+                                value="{{ $deal->value }}" />
                         </x-forms.input-group>
                     </div>
                     <div class="col-md-5 col-lg-4 dueDateBox mt-1">
-                        <x-forms.datepicker fieldId="close_date" class="custom-date-picker" fieldRequired="true" :fieldLabel="__('modules.deal.closeDate')"
-                                fieldName="close_date" :fieldPlaceholder="__('placeholders.date')"
-                                :fieldValue="(($deal->close_date) ? $deal->close_date->format(company()->date_format) : '')"/>
+                        <x-forms.datepicker fieldId="close_date" class="custom-date-picker" fieldRequired="true"
+                            :fieldLabel="__('modules.deal.closeDate')" fieldName="close_date" :fieldPlaceholder="__('placeholders.date')" :fieldValue="$deal->close_date ? $deal->close_date->format(company()->date_format) : ''" />
                     </div>
 
-                    @if(in_array('products', user_modules()) || in_array('purchase', user_modules()))
+                    @if (in_array('products', user_modules()) || in_array('purchase', user_modules()))
                         <div class="col-lg-4 mt-3">
                             <div class="form-group">
-                                <x-forms.label fieldId="selectProduct" :fieldLabel="__('app.menu.products')" >
+                                <x-forms.label fieldId="selectProduct" :fieldLabel="__('app.menu.products')">
                                 </x-forms.label>
                                 <x-forms.input-group>
-                                    <select class="form-control select-picker" data-live-search="true" data-size="8"  name="product_id[]" multiple  id="add-products" title="{{ __('app.menu.selectProduct') }}">
+                                    <select class="form-control select-picker" data-live-search="true" data-size="8"
+                                        name="product_id[]" multiple id="add-products"
+                                        title="{{ __('app.menu.selectProduct') }}">
                                         @foreach ($products as $item)
-                                            <option @selected(in_array($item->id, $productIds)) data-content="{{ $item->name }}" value="{{ $item->id }}">
+                                            <option @selected(in_array($item->id, $productIds)) data-content="{{ $item->name }}"
+                                                value="{{ $item->id }}">
                                                 {{ $item->name }}</option>
                                         @endforeach
                                     </select>
@@ -143,18 +157,26 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
                     @endif
 
                     <div class="col-lg-4 col-md-6">
-                        <x-forms.select fieldId="deal_watcher" :fieldLabel="__('app.dealWatcher')"
-                                        fieldName="deal_watcher">
+                        <x-forms.select fieldId="deal_watcher" :fieldLabel="__('app.dealWatcher')" fieldName="deal_watcher">
                             <option value="">--</option>
                             @foreach ($employees as $item)
-                                <x-user-option :user="$item" :selected="($deal->deal_watcher == $item->id)"/>
+                                <x-user-option :user="$item" :selected="$deal->deal_watcher == $item->id" />
                             @endforeach
                         </x-forms.select>
                     </div>
 
                 </div>
 
-                <x-forms.custom-field :fields="$fields" :model="$deal"></x-forms.custom-field>
+                @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
+                    @foreach ($customFieldCategories as $category)
+                        <div class="custom-fields-category-container" id="custom-fields-category-{{ $category->id }}"
+                            style="display: none;">
+                            <x-forms.custom-field :fields="$fields" :model="$deal" :categoryId="$category->id" />
+                        </div>
+                    @endforeach
+                @endif
+
+                {{-- <x-forms.custom-field :fields="$fields" :model="$deal"></x-forms.custom-field> --}}
 
                 <x-form-actions>
                     <x-forms.button-primary id="save-lead-form" class="mr-3" icon="check">@lang('app.save')
@@ -183,7 +205,8 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
         $('#save-lead-form').click(function() {
 
             const tab = "{{ $tab }}";
-            const url = tab != null ? "{{ route('deals.update', [$deal->id]) }}?tab=" + tab : "{{ route('deals.update', [$deal->id]) }}";
+            const url = tab != null ? "{{ route('deals.update', [$deal->id]) }}?tab=" + tab :
+                "{{ route('deals.update', [$deal->id]) }}";
 
             $.easyAjax({
                 url: url,
@@ -202,7 +225,7 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
 
         $('body').on('click', '.add-lead-agent', function() {
             var categoryId = $('#category_id').val();
-            var url = "{{ route('lead-agent-settings.create').'?categoryId='}}"+categoryId;
+            var url = "{{ route('lead-agent-settings.create') . '?categoryId=' }}" + categoryId;
             $(MODAL_LG + ' ' + MODAL_HEADING).html('...');
             $.ajaxModal(MODAL_LG, url);
         });
@@ -275,14 +298,14 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
             });
         });
 
-        $('#editPipeline').on("change", function (e) {
+        $('#editPipeline').on("change", function(e) {
             let pipelineId = $(this).val();
             getStages(pipelineId)
         });
 
         getStages($('#editPipeline').val());
         var selectedStageId = {{ $deal->pipeline_stage_id }};
-         // GET STAGES
+        // GET STAGES
         function getStages(pipelineId) {
             var url = "{{ route('deals.get-stage', ':id') }}";
             url = url.replace(':id', pipelineId);
@@ -290,15 +313,16 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
             $.easyAjax({
                 url: url,
                 type: "GET",
-                success: function (response) {
+                success: function(response) {
                     if (response.status == 'success') {
                         var options = [];
                         var rData = [];
                         rData = response.data;
-                        $.each(rData, function (index, value) {
+                        $.each(rData, function(index, value) {
                             var selectData = '';
                             var selected = value.id == selectedStageId ? 'selected' : '';
-                            selectData = `<option data-content="<i class='fa fa-circle' style='color: ${value.label_color}'></i> ${value.name} " value="${value.id}" ${selected}> ${value.name}</option>`;
+                            selectData =
+                                `<option data-content="<i class='fa fa-circle' style='color: ${value.label_color}'></i> ${value.name} " value="${value.id}" ${selected}> ${value.name}</option>`;
                             options.push(selectData);
                         });
 
@@ -328,36 +352,31 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
             });
         });
         var categoryId = $('#category_id').val();
-        if(categoryId != '')
-        {
+        if (categoryId != '') {
             getAgents(categoryId);
         }
 
-        function getAgents(categoryId){
-            var url = "{{ route('deals.get_agents', ':id')}}";
+        function getAgents(categoryId) {
+            var url = "{{ route('deals.get_agents', ':id') }}";
             url = url.replace(':id', categoryId);
-            var dealId = "{{$deal->id}}";
+            var dealId = "{{ $deal->id }}";
             $.easyAjax({
                 url: url,
                 type: "GET",
                 data: {
-                    dealId : dealId,
+                    dealId: dealId,
                 },
-                success: function(response)
-                {
+                success: function(response) {
                     var options = [];
                     var rData = [];
-                    if($.isArray(response.data))
-                    {
+                    if ($.isArray(response.data)) {
                         rData = response.data;
                         $.each(rData, function(index, value) {
                             var selectData = '';
                             options.push(value);
                         });
                         $('#deal_agent_id').html('<option value="">--</option>' + options);
-                    }
-                    else
-                    {
+                    } else {
                         $('#deal_agent_id').html(response.data);
                     }
                     $('#deal_agent_id').selectpicker('refresh');
@@ -365,10 +384,9 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
             });
         }
 
-        $('#category_id').change(function(){
+        $('#category_id').change(function() {
             var id = $(this).val();
-            if(id != '')
-            {
+            if (id != '') {
                 getAgents(id);
             }
         });
@@ -377,5 +395,4 @@ $changeDealStagesPermission = user()->permission('change_deal_stages');
 
         init(RIGHT_MODAL);
     });
-
 </script>

--- a/resources/views/leads/ajax/profile.blade.php
+++ b/resources/views/leads/ajax/profile.blade.php
@@ -4,7 +4,6 @@
     <div class="col-sm-9 mb-4 mb-xl-0 mb-lg-4 mb-md-0">
 
         <x-cards.data :title="__('modules.deal.dealInfo')">
-
             <x-slot name="customFieldCategories">
                 <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
             </x-slot>

--- a/resources/views/leads/ajax/show.blade.php
+++ b/resources/views/leads/ajax/show.blade.php
@@ -8,7 +8,7 @@ $viewLeadFollowupPermission = user()->permission('view_lead_follow_up');
 
 <div id="task-detail-section">
 
-    <h3 class="heading-h1 mb-3">{{ $deal->name }}</h3>
+    {{-- <h3 class="heading-h1 mb-3">{{ $deal->name }}</h3> --}}
 
     <div class="row">
         <!--  USER CARDS START -->
@@ -16,6 +16,9 @@ $viewLeadFollowupPermission = user()->permission('view_lead_follow_up');
 
             <x-cards.data :title="__('modules.deal.dealInfo')">
 
+                <x-slot name="customFieldCategories">
+                    <x-custom-field-category-tabs :customFieldCategories="$customFieldCategories" />
+                </x-slot>
                 <x-slot name="action">
                     <div class="dropdown">
                         <button class="btn f-14 px-0 py-0 text-dark-grey dropdown-toggle" type="button"
@@ -42,72 +45,86 @@ $viewLeadFollowupPermission = user()->permission('view_lead_follow_up');
                     </div>
                 </x-slot>
 
-                <p class="f-w-500">
-                    <x-status style="color: {{ $deal->pipeline->label_color }}" color="yellow"
-                                :value="$deal->pipeline->name"/>
-                    <i class="bi bi-arrow-right mx-"></i>
-                    <x-status style="color: {{ $deal->leadStage->label_color }}" color="yellow"
-                                :value="$deal->leadStage->name"/>
-                </p>
-                <x-cards.data-row :label="__('modules.deal.dealName')" :value="$deal->name ?? '--'"/>
-
-
-
-                <x-cards.data-row :label="__('modules.leadContact.leadContact')"
-                                    :value="$deal->contact->client_name_salutation ?? '--'"/>
-
-                <x-cards.data-row :label="__('app.email')" :value="$deal->contact->client_email ?? '--'"/>
-
-                <x-cards.data-row :label="__('modules.lead.companyName')"
-                                    :value="!empty($deal->contact->company_name) ? $deal->contact->company_name : '--'"/>
-
-                <x-cards.data-row :label="__('modules.deal.dealCategory')"
-                                    :value="$deal->category->category_name ?? '--'"/>
-
-                <div class="col-12 px-0 pb-3 d-flex">
-                    <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">
-                        @lang('modules.deal.dealAgent')</p>
-                    <p class="mb-0 text-dark-grey f-14">
-                        @if (!is_null($deal->leadAgent))
-                            <x-employee :user="$deal->leadAgent->user"/>
-                        @else
-                            --
-                        @endif
+                <div id="normal-fields-container">
+                    <p class="f-w-500">
+                        <x-status style="color: {{ $deal->pipeline->label_color }}" color="yellow"
+                                    :value="$deal->pipeline->name"/>
+                        <i class="bi bi-arrow-right mx-"></i>
+                        <x-status style="color: {{ $deal->leadStage->label_color }}" color="yellow"
+                                    :value="$deal->leadStage->name"/>
                     </p>
-                </div>
+                    <div class="row">
 
-                <div class="col-12 px-0 pb-3 d-flex">
-                    <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">{{ __('app.dealWatcher') }}</p>
-                    <p class="mb-0 text-dark-grey f-14">
-                        @if (!is_null($deal->dealWatcher))
-                            <x-employee :user="$deal->dealWatcher"/>
-                        @else
-                            --
+                        <x-cards.data-row :label="__('modules.deal.dealName')" :value="$deal->name ?? '--'"/>
+        
+                        <x-cards.data-row :label="__('modules.leadContact.leadContact')"
+                                            :value="$deal->contact->client_name_salutation ?? '--'"/>
+        
+                        <x-cards.data-row :label="__('app.email')" :value="$deal->contact->client_email ?? '--'"/>
+        
+                        <x-cards.data-row :label="__('modules.lead.companyName')"
+                                            :value="!empty($deal->contact->company_name) ? $deal->contact->company_name : '--'"/>
+        
+                        <x-cards.data-row :label="__('modules.deal.dealCategory')"
+                                            :value="$deal->category->category_name ?? '--'"/>
+        
+                        <div class="col-6 px-0 pb-3 d-flex">
+                            <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">
+                                @lang('modules.deal.dealAgent')</p>
+                            <p class="mb-0 text-dark-grey f-14">
+                                @if (!is_null($deal->leadAgent))
+                                    <x-employee :user="$deal->leadAgent->user"/>
+                                @else
+                                    --
+                                @endif
+                            </p>
+                        </div>
+        
+                        <div class="col-6 px-0 pb-3 d-flex">
+                            <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">{{ __('app.dealWatcher') }}</p>
+                            <p class="mb-0 text-dark-grey f-14">
+                                @if (!is_null($deal->dealWatcher))
+                                    <x-employee :user="$deal->dealWatcher"/>
+                                @else
+                                    --
+                                @endif
+                            </p>
+                        </div>
+        
+                        @if ($deal->leadStatus)
+                            <div class="col-12 px-0 pb-3 d-flex">
+                                <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">@lang('app.status')</p>
+                                <p class="mb-0 text-dark-grey f-14">
+                                    <x-status :value="$deal->leadStatus->type"
+                                                :style="'color:'.$deal->leadStatus->label_color"/>
+                                </p>
+        
+                            </div>
                         @endif
-                    </p>
-                </div>
-
-                @if ($deal->leadStatus)
-                    <div class="col-12 px-0 pb-3 d-flex">
-                        <p class="mb-0 text-lightest f-14 w-30 d-inline-block ">@lang('app.status')</p>
-                        <p class="mb-0 text-dark-grey f-14">
-                            <x-status :value="$deal->leadStatus->type"
-                                        :style="'color:'.$deal->leadStatus->label_color"/>
-                        </p>
-
+        
+                        <x-cards.data-row :label="__('modules.deal.closeDate')"
+                                            :value="($deal->close_date) ? $deal->close_date->translatedFormat(company()->date_format) : '--'"/>
+                        <x-cards.data-row :label="__('modules.deal.dealValue')"
+                                            :value="($deal->value) ? currency_format($deal->value, $deal->currency_id) : '--'"/>
+        
+                        <x-cards.data-row :label="__('modules.lead.products')"
+                                            :value="($productNames) ? implode(', ' , $productNames) : '--'"/>
                     </div>
+
+                </div>
+                
+            {{-- Custom fields data --}}
+            <div id="custom-fields-category-container">
+                @if (isset($customFieldCategories) && count($customFieldCategories) > 0)
+                    @foreach ($customFieldCategories as $category)
+                        <div class="row custom-fields-category-container"
+                            id="custom-fields-category-{{ $category->id }}" style="display: none;">
+                            <x-forms.custom-field-show :fields="$fields" :model="$deal"
+                                :categoryId="$category->id"></x-forms.custom-field-show>
+                        </div>
+                    @endforeach
                 @endif
-
-                <x-cards.data-row :label="__('modules.deal.closeDate')"
-                                    :value="($deal->close_date) ? $deal->close_date->translatedFormat(company()->date_format) : '--'"/>
-                <x-cards.data-row :label="__('modules.deal.dealValue')"
-                                    :value="($deal->value) ? currency_format($deal->value, $deal->currency_id) : '--'"/>
-
-                <x-cards.data-row :label="__('modules.lead.products')"
-                                    :value="($productNames) ? implode(', ' , $productNames) : '--'"/>
-
-                {{-- Custom fields data --}}
-                <x-forms.custom-field-show :fields="$fields" :model="$deal"></x-forms.custom-field-show>
+            </div>
 
             </x-cards.data>
 
@@ -157,7 +174,7 @@ $viewLeadFollowupPermission = user()->permission('view_lead_follow_up');
         <div class="col-sm-3">
 
 
-            <x-cards.data :title="__('modules.leadContact.leadDetails')">
+            {{-- <x-cards.data :title="__('modules.leadContact.leadDetails')">
 
                 <x-cards.data-row :label="__('modules.leadContact.leadContact')" otherClasses="pr-1" labelClasses="pr-1"
                                     value="<a href='{{ route('lead-contact.show', $deal->contact->id) }}' class='text-darkest-grey'> {{ $deal->contact->client_name_salutation }}</a>"/>
@@ -180,7 +197,7 @@ $viewLeadFollowupPermission = user()->permission('view_lead_follow_up');
                     @endif
                 </div>
 
-            </x-cards.data>
+            </x-cards.data> --}}
         </div>
     </div>
 

--- a/resources/views/leads/board/index.blade.php
+++ b/resources/views/leads/board/index.blade.php
@@ -38,9 +38,10 @@
 
             <x-alert type="warning" icon="info" class="d-lg-none">@lang('messages.dragDropScreenInfo')</x-alert>
 
-            <div id="table-actions" class="flex-grow-1 align-items-center">
+            <div id="table-actions" class="flex-grow flex items-center gap-4">
+                <h3 class="heading-h1 inline-flex">{{ $currentPipelineName ?? 'All Pipelines' }}</h3>
                 @if ($addLeadPermission == 'all' || $addLeadPermission == 'added')
-                    <x-forms.link-primary :link="route('deals.create')" class="mr-3 openRightModal float-left" icon="plus">
+                    <x-forms.link-primary :link="route('deals.create')" class="openRightModal float-left" icon="plus">
                         @lang('modules.deal.addDeal')
                     </x-forms.link-primary>
                 @endif
@@ -116,8 +117,21 @@
                     $("body").tooltip({
                         selector: '[data-toggle="tooltip"]'
                     });
+                    
+                    // Update the pipeline heading
+                    updatePipelineHeading();
                 }
             });
+        }
+
+        function updatePipelineHeading() {
+            var pipelineSelect = $('#pipeline');
+            var selectedOption = pipelineSelect.find('option:selected');
+            var pipelineName = selectedOption.text();
+            
+            if (pipelineName) {
+                $('.heading-h1').text(pipelineName);
+            }
         }
 
         $('body').on('click', '.load-more-tasks', function() {
@@ -319,5 +333,6 @@
         });
 
         showTable();
+        updatePipelineHeading();
     </script>
 @endpush

--- a/resources/views/leads/index.blade.php
+++ b/resources/views/leads/index.blade.php
@@ -18,9 +18,10 @@ $addLeadCustomFormPermission = user()->permission('manage_lead_custom_forms');
     <div class="content-wrapper">
         <!-- Add Task Export Buttons Start -->
         <div class="d-grid d-lg-flex d-md-flex action-bar">
-            <div id="table-actions" class="flex-grow-1 align-items-center">
+            <div id="table-actions" class="flex-grow flex items-center gap-4">
+                <h3 class="heading-h1 inline-flex">{{ $currentPipelineName ?? 'All Pipelines' }}</h3>
                 @if ($addLeadPermission == 'all' || $addLeadPermission == 'added')
-                    <x-forms.link-primary :link="route('deals.create')" class="mr-3 float-left mb-2 mb-lg-0 mb-md-0 openRightModal" icon="plus">
+                    <x-forms.link-primary :link="route('deals.create')" class="float-left mb-2 mb-lg-0 mb-md-0 openRightModal" icon="plus">
                         @lang('modules.deal.addDeal')
                     </x-forms.link-primary>
                 @endif
@@ -124,7 +125,20 @@ $addLeadCustomFormPermission = user()->permission('manage_lead_custom_forms');
         });
         const showTable = () => {
             window.LaravelDataTables["leads-table"].draw(true);
+            updatePipelineHeading();
         }
+
+        function updatePipelineHeading() {
+            var pipelineSelect = $('#pipeline');
+            var selectedOption = pipelineSelect.find('option:selected');
+            var pipelineName = selectedOption.text();
+            if (pipelineName) {
+                $('.heading-h1').text(pipelineName);
+            }
+        }
+
+        // Initial heading update
+        updatePipelineHeading();
         $('#reset-filters').click(function() {
             $('#filter-form')[0].reset();
             $('.filter-box #status').val('not finished');


### PR DESCRIPTION
Introduces support for custom field category tabs in deal create, edit, and show views. Updates DealController to provide custom field categories, and enhances the custom field tabs component for better UI. Also includes minor code cleanups and improvements to pipeline heading display in leads board and deals table views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The current pipeline name is now displayed dynamically in the leads board and deals table views, providing clearer context for users.
  * Custom field categories are now available and organized with tabs in deal and lead forms, improving the management and visibility of custom fields.

* **Style**
  * Improved layout and spacing for category tabs and form sections, ensuring better responsiveness and readability.

* **Bug Fixes**
  * Headings and UI elements now update in real-time when pipeline selections change, ensuring accurate display without page reloads.

* **Documentation**
  * Updated changelog to reflect recent enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->