### PR TITLE
Feature/hib 191 rename deal agent responsible person

### DIFF
--- a/resources/lang/eng/modules.php
+++ b/resources/lang/eng/modules.php
@@ -2386,7 +2386,7 @@ return array(
         'dealStageTooltip' => 'A New note will be create when stage changes to win or lost.',
         'category' => 'Category',
         'product' => 'Product',
-        'assignAgent' => 'Assigned Agent',
+        'assignAgent' => 'Assign Responsible Person',
     ),
     'estimateRequest' => array(
         'estimateRequest' => 'Estimate Request',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization**
  - Updated deal-related labels for improved clarity and consistency across the app.
  - “Deal Agent” is now “Responsible Person.”
  - “Assign Agent” is now “Assign Responsible Person.”
  - Changes apply to deal pages, forms, and filters where these labels appear.
  - UI text only; no functional behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->