### PR TITLE
Feature/hib 225 unique links per employee

### DIFF
--- a/app/Enums/CommissionStatus.php
+++ b/app/Enums/CommissionStatus.php
@@ -9,6 +9,8 @@ enum CommissionStatus: string
     case Paid      = 'paid';
     case Cancelled = 'cancelled';
 
+
+
     public function label(): string
     {
         return match ($this) {

--- a/app/Enums/CommissionStatus.php
+++ b/app/Enums/CommissionStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum CommissionStatus: string
+{
+    case Pending   = 'pending';
+    case Approved  = 'approved';
+    case Paid      = 'paid';
+    case Cancelled = 'cancelled';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending, self::Approved, self::Paid, self::Cancelled => __('app.commissionStatus.' . $this->value),
+            default => $this->value,
+        };
+    }
+
+    public static function toArray(): array
+    {
+        $statuses = [];
+        foreach (CommissionStatus::cases() as $status) {
+            $statuses[] = $status->value;
+        }
+        return $statuses;
+    }
+}

--- a/app/Jobs/BackfillReferralCodesJob.php
+++ b/app/Jobs/BackfillReferralCodesJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class BackfillReferralCodesJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        //
+        Employee::doesntHave('referralCode') // only employees without codes
+            ->chunkById(100, function ($employees) {
+                foreach ($employees as $employee) {
+                    ReferralCode::firstOrCreate(
+                        ['employee_id' => $employee->id],
+                        ['code' => ReferralCode::generateCode()]
+                    );
+                }
+            });
+    }
+}

--- a/app/Models/Commission.php
+++ b/app/Models/Commission.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Commission extends Model
+{
+    use HasFactory;
+
+    protected $table = 'commissions';
+
+    protected $fillable = [
+        'employee_id',
+        'event_type',
+        'source_event_id',
+        'amount',
+        'level',
+        'rule_version',
+        'status',
+    ];
+
+    /**
+     * The employee who earned the commission.
+     */
+    public function employee()
+    {
+        return $this->belongsTo(EmployeeDetails::class, 'employee_id');
+    }
+}

--- a/app/Models/Commission.php
+++ b/app/Models/Commission.php
@@ -4,12 +4,18 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Enums\CommissionStatus;
 
 class Commission extends Model
 {
     use HasFactory;
 
     protected $table = 'commissions';
+    protected $casts = [
+       'status' => CommissionStatus::class,
+       'amount' => 'decimal:2',
+       'level'  => 'integer',
+    ];
 
     protected $fillable = [
         'employee_id',

--- a/app/Models/Commission.php
+++ b/app/Models/Commission.php
@@ -26,6 +26,10 @@ class Commission extends Model
         'rule_version',
     ];
 
+    protected $attributes = [
+        'status' => CommissionStatus::Pending->value,
+    ];
+
     // Methods for status transitions for Commission
      /**
       * Approve the commission if it's currently pending.
@@ -34,11 +38,14 @@ class Commission extends Model
       */
     public function approve()
     {
-        if ($this->status !== CommissionStatus::Pending) {
+         $updated = static::query()
+        ->whereKey($this->getKey())
+        ->where('status', CommissionStatus::Pending)
+        ->update(['status' => CommissionStatus::Approved]);
+        if ($updated !== 1) {
             throw new \DomainException('Only pending commissions can be approved.');
         }
-        $this->status = CommissionStatus::Approved;
-        $this->save();
+        $this->refresh();
     }
 
     /**
@@ -48,11 +55,14 @@ class Commission extends Model
      */
     public function markPaid()
     {
-        if ($this->status !== CommissionStatus::Approved) {
-            throw new \DomainException('Only approved commissions can be marked as paid.');
-        }
-        $this->status = CommissionStatus::Paid;
-        $this->save();
+        $updated = static::query()
+        ->whereKey($this->getKey())
+        ->where('status', CommissionStatus::Approved)
+        ->update(['status' => CommissionStatus::Paid]);
+       if ($updated !== 1) {
+           throw new \DomainException('Only approved commissions can be marked as paid.');
+       }
+       $this->refresh();
     }
     /**
      * Cancel the commission unless it's already paid.
@@ -62,11 +72,14 @@ class Commission extends Model
 
     public function cancel()
     {
-        if ($this->status === CommissionStatus::Paid) {
-            throw new \DomainException('Paid commissions cannot be cancelled.');
+        $updated = static::query()
+            ->whereKey($this->getKey())
+            ->whereIn('status', [CommissionStatus::Pending, CommissionStatus::Approved])
+            ->update(['status' => CommissionStatus::Cancelled]);
+        if ($updated !== 1) {
+            throw new \DomainException('Only pending or approved commissions can be cancelled.');
         }
-        $this->status = CommissionStatus::Cancelled;
-        $this->save();
+        $this->refresh();
     }
 
     /**

--- a/app/Models/Commission.php
+++ b/app/Models/Commission.php
@@ -24,8 +24,50 @@ class Commission extends Model
         'amount',
         'level',
         'rule_version',
-        'status',
     ];
+
+    // Methods for status transitions for Commission
+     /**
+      * Approve the commission if it's currently pending.
+      *
+      * @throws \DomainException if the commission is not in a pending state.
+      */
+    public function approve()
+    {
+        if ($this->status !== CommissionStatus::Pending) {
+            throw new \DomainException('Only pending commissions can be approved.');
+        }
+        $this->status = CommissionStatus::Approved;
+        $this->save();
+    }
+
+    /**
+     * Mark the commission as paid if it's currently approved.
+     *
+     * @throws \DomainException if the commission is not in an approved state.
+     */
+    public function markPaid()
+    {
+        if ($this->status !== CommissionStatus::Approved) {
+            throw new \DomainException('Only approved commissions can be marked as paid.');
+        }
+        $this->status = CommissionStatus::Paid;
+        $this->save();
+    }
+    /**
+     * Cancel the commission unless it's already paid.
+     *
+     * @throws \DomainException if the commission is already paid.
+     */
+
+    public function cancel()
+    {
+        if ($this->status === CommissionStatus::Paid) {
+            throw new \DomainException('Paid commissions cannot be cancelled.');
+        }
+        $this->status = CommissionStatus::Cancelled;
+        $this->save();
+    }
 
     /**
      * The employee who earned the commission.

--- a/app/Models/EmployeeDetails.php
+++ b/app/Models/EmployeeDetails.php
@@ -155,7 +155,7 @@ class EmployeeDetails extends BaseModel
         return $this->belongsTo(EmployeeDetails::class, 'referral_id');
     }
 
-    // also referred to dowwnlines ...
+    // also referred to as downlines ...
     public function referrals(): HasMany
     {
         return $this->hasMany(EmployeeDetails::class, 'referral_id');

--- a/app/Models/EmployeeDetails.php
+++ b/app/Models/EmployeeDetails.php
@@ -140,4 +140,24 @@ class EmployeeDetails extends BaseModel
         return $this->belongsTo(Team::class, 'department_id');
     }
 
+    public function commissions(): HasMany
+    {
+        return $this->hasMany(Commission::class, 'employee_id');
+    }
+
+    public function referralCode(): HasOne
+    {
+        return $this->hasOne(ReferralCode::class, 'employee_id');
+    }
+
+    public function referrer(): BelongsTo
+    {
+        return $this->belongsTo(EmployeeDetails::class, 'referral_id');
+    }
+
+    // also referred to dowwnlines ...
+    public function referrals(): HasMany
+    {
+        return $this->hasMany(EmployeeDetails::class, 'referral_id');
+    }
 }

--- a/app/Models/EmployeeDetails.php
+++ b/app/Models/EmployeeDetails.php
@@ -8,6 +8,8 @@ use App\Traits\CustomFieldsTrait;
 use App\Traits\HasCompany;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * App\Models\EmployeeDetails

--- a/app/Models/ReferralCode.php
+++ b/app/Models/ReferralCode.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ReferralCode extends Model
+{
+    use HasFactory;
+
+    protected $table = 'referral_codes';
+
+    protected $fillable = [
+        'employee_id',
+        'referral_code',
+    ];
+
+    /**
+     * Get the employee details associated with this referral code.
+     */
+    public function employee()
+    {
+        return $this->belongsTo(EmployeeDetails::class, 'employee_id');
+    }
+}

--- a/app/Models/ReferralCode.php
+++ b/app/Models/ReferralCode.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReferralCode extends Model
 {
@@ -19,8 +20,32 @@ class ReferralCode extends Model
     /**
      * Get the employee details associated with this referral code.
      */
-    public function employee()
+    public function employee(): BelongsTo
     {
         return $this->belongsTo(EmployeeDetails::class, 'employee_id');
+    }
+
+
+    
+    /**
+     * Generate a new unique referral code.
+     */
+    public static function generateCode(): string
+    {
+        // Get the company prefix from settings if needed, or from the employee's company
+        $companyPrefix = company() ? strtoupper(substr(company()->name, 0, 3)) . '-' : '';
+        
+        do {
+            $code = $companyPrefix . strtoupper(Str::random(8));
+        } while (self::where('referral_code', $code)->exists());
+
+        return $code;
+    }
+
+    // getReferralLink
+    public function getReferralLink(): string
+    {
+        // TODO: Ensure that a referral route is fleshed out
+        return url('/referral/' . $this->referral_code);
     }
 }

--- a/app/Observers/EmployeeDetailsObserver.php
+++ b/app/Observers/EmployeeDetailsObserver.php
@@ -8,6 +8,8 @@ use App\Models\EmployeeDetails;
 use App\Models\EmployeeLeaveQuota;
 use App\Events\NewUserSlackEvent;
 use App\Models\User;
+use App\Models\ReferralCode;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Artisan;
 
 class EmployeeDetailsObserver
@@ -43,6 +45,14 @@ class EmployeeDetailsObserver
         Artisan::call('app:recalculate-leaves-quotas ' . $detail->company_id . ' ' . $user->id);
 
         event(new NewUserSlackEvent($user));
+
+        // create a referral code for the employee
+         if (!ReferralCode::where('employee_id', $employee->id)->exists()) {
+            ReferralCode::create([
+                'employee_id' => $employee->id,
+                'code' => ReferralCode::generateCode(),
+            ]);
+        }
 
 
     }

--- a/database/migrations/2025_09_06_002718_add_mlm_details_to_employee_details_table.php
+++ b/database/migrations/2025_09_06_002718_add_mlm_details_to_employee_details_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employee_details', function (Blueprint $table) {
+            $table->unsignedInteger('referral_id')->nullable()->index();
+            $table->integer('level')->default(1);
+
+            $table->foreign('referral_id')->references('id')->on('employee_details')->onDelete('set null');
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employee_details', function (Blueprint $table) {
+            $table->dropForeign(['referral_id']);
+            $table->dropColumn(['referral_id', 'level']);
+        });
+    }
+};

--- a/database/migrations/2025_09_06_015228_create_referral_codes_table.php
+++ b/database/migrations/2025_09_06_015228_create_referral_codes_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('referral_codes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('employee_id')->unique(); 
+            $table->string('referral_code')->unique(); 
+            $table->timestamps();
+
+            $table->foreign('employee_id')
+                  ->references('id')->on('employee_details')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('referral_codes');
+    }
+};

--- a/database/migrations/2025_09_06_015312_create_commissions_table.php
+++ b/database/migrations/2025_09_06_015312_create_commissions_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('commissions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('employee_id'); // who earned the commission
+            $table->string('event_type'); // type of event responsible for commission
+            $table->unsignedInteger('source_event_id'); // ID of the event record
+            $table->decimal('amount', 12, 2); // commission amount
+            $table->unsignedTinyInteger('level')->default(1); // MLM level 
+            $table->string('rule_version')->nullable(); // rule version at time of calculation
+            $table->string('status')->default('pending'); // status of the commission
+            $table->timestamps();
+
+            $table->foreign('employee_id')
+                  ->references('id')->on('employee_details')
+                  ->onDelete('cascade');
+
+            $table->index(['event_type', 'source_event_id']); 
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('commissions');
+    }
+};

--- a/database/migrations/2025_09_06_015312_create_commissions_table.php
+++ b/database/migrations/2025_09_06_015312_create_commissions_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->unsignedInteger('employee_id'); // who earned the commission
             $table->string('event_type'); // type of event responsible for commission
             $table->unsignedInteger('source_event_id'); // ID of the event record
-            $table->decimal('amount', 12, 2); // commission amount
+            $table->unsignedDecimal('amount', 12, 2); // commission amount
             $table->unsignedTinyInteger('level')->default(1); // MLM level 
             $table->string('rule_version')->nullable(); // rule version at time of calculation
             $table->string('status')->default('pending'); // status of the commission

--- a/resources/lang/eng/app.php
+++ b/resources/lang/eng/app.php
@@ -1259,6 +1259,12 @@ return array(
     'moduleNotifySwitchMessage' => 'This will hide/show new update message on dashboard for :name module',
     'leadContact' => 'Lead Contact',
     'deal' => 'Deals',
+    'commissionStatus' => array(
+        'pending' => 'Pending',
+        'approved' => 'Approved',
+        'paid' => 'Paid',
+        'cancelled' => 'Cancelled'
+    ),
     'maritalStatus' => array(
         'single' => 'Single',
         'married' => 'Married',


### PR DESCRIPTION

**Changes Made: Unique Referral Links for Employees**

* Built on the **Employee Model Updates** branch, which contains the necessary migrations and models for referral codes.
* **chore:** Added `generateCode` and `getReferralLink` methods in the `ReferralCode` model to centralize referral code generation and link retrieval.
* **chore:** Updated `EmployeeDetailsObserver` to automatically create a referral code whenever a new `employee_details` record is added.
* **chore:** Created a queued job to retroactively generate referral codes for existing employee records that don’t yet have them.
* Ensure referral codes account for company separation when generating and retrieving links, primarily via the company_id present in employee_details table

