### PR TITLE
Feature/hib 246 link deals to payments

### DIFF
--- a/app/Models/Deal.php
+++ b/app/Models/Deal.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Payment;
 
 /**
  * App\Models\Lead
@@ -250,6 +251,13 @@ class Deal extends BaseModel
     public function addedBy()
     {
         return $this->belongsTo(User::class, 'added_by')->withoutGlobalScope(ActiveScope::class);
+    }
+
+
+    // payments relation
+    public function payments(): HasMany
+    {
+        return $this->hasMany(Payment::class, 'deal_id');
     }
 
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -7,6 +7,7 @@ use App\Traits\HasCompany;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Deal;
 
 /**
  * App\Models\Payment
@@ -212,6 +213,12 @@ class Payment extends BaseModel
                 return $this->amount;
             },
         );
+    }
+
+    // deal relation
+    public function deal(): BelongsTo
+    {
+        return $this->belongsTo(Deal::class, 'deal_id');
     }
 
 }

--- a/database/migrations/2025_09_09_055815_adds_deal_id_to_payments_table.php
+++ b/database/migrations/2025_09_09_055815_adds_deal_id_to_payments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            //
+            $table->unsignedBigInteger('deal_id')->nullable()->after('id');
+            $table->foreign('deal_id')->references('id')->on('deals')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            //
+            $table->dropForeign(['deal_id']);
+            $table->dropColumn('deal_id');
+        });
+    }
+};


### PR DESCRIPTION

**Changes Made: Link Deals to Payments**

* Added `deal_id` to the `payments` table to establish a one-to-many relationship between `deals` and `payments`.
* Updated the corresponding models to reflect this relationship for proper ORM handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Payments can now be associated with a specific deal.
  - View all payments linked to a deal in one place.
  - Navigate from a payment to its related deal for quicker context.
  - Improved data consistency between deals and payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->