### PR TITLE
feat: Implement meeting summary API with platform validation

### DIFF
--- a/app/Http/Controllers/MeetingSummaryApiController.php
+++ b/app/Http/Controllers/MeetingSummaryApiController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DealFollowUp;
+use App\Models\MeetingSummary;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class MeetingSummaryApiController extends Controller
+{
+    public function getMeetingSummary(Request $request): JsonResponse
+    {
+        $request->validate([
+            'meeting_summary' => 'required|array',
+            'meeting_id' => 'required|string',
+            'meeting_platform' => 'required|string'
+        ]);
+
+        $meetingSummary = $request->input('meeting_summary');
+        $meetingId = $request->input('meeting_id');
+        $meetingPlatform = $request->input('meeting_platform');
+
+        $meetingInfo = $this->findOrFailMeetingId($meetingId, $meetingPlatform);
+        
+        if ($meetingInfo instanceof JsonResponse) {
+            return $meetingInfo;
+        }
+
+        // Check if a summary already exists for this meeting
+        $leadFollowUp = DealFollowUp::where('meeting_id', $meetingId)->first();
+        
+        if ($leadFollowUp && $leadFollowUp->summary_id) {
+            // Update existing summary
+            $summary = MeetingSummary::find($leadFollowUp->summary_id);
+            if ($summary) {
+                $summary->update([
+                    'summary_object' => $meetingSummary,
+                    'meeting_type_id' => $meetingInfo['meeting_type_id'],
+                    'deal_id' => $meetingInfo['deal_id'],
+                ]);
+                
+                return response()->json([
+                    'success' => true,
+                    'message' => 'Meeting summary updated successfully',
+                    'action' => 'updated'
+                ], 200);
+            }
+        }
+        
+        // Create new summary
+        $summary = MeetingSummary::create([
+            'summary_object' => $meetingSummary,
+            'meeting_type_id' => $meetingInfo['meeting_type_id'],
+            'deal_id' => $meetingInfo['deal_id'],
+        ]);
+
+        // Update the lead_follow_up record with the summary_id
+        if ($leadFollowUp) {
+            $leadFollowUp->update(['summary_id' => $summary->id]);
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Meeting summary created successfully',
+            'data' => $summary,
+            'action' => 'created'
+        ], 201);
+    }
+
+    private function findOrFailMeetingId(string $meetingId, string $meetingPlatform)
+    {
+        $meeting = [];
+        $meeting['deal_id'] = null;
+        $meeting['meeting_type_id'] = null;
+        
+        if(!$meetingId){
+            return response()->json(['error' => 'Meeting ID is required'], 400);
+        }
+        
+        if(!$meetingPlatform){
+            return response()->json(['error' => 'Meeting platform is required'], 400);
+        }
+        
+        // Get all meetings with the same meeting_id
+        $meetings = DealFollowUp::where('meeting_id', $meetingId)->get();
+        
+        if($meetings->isEmpty()){
+            return response()->json(['error' => 'Meeting not found'], 404);
+        }
+        
+        // Find the meeting that matches the platform/location
+        $meetingInfo = $meetings->firstWhere('location', $meetingPlatform);
+        
+        if(!$meetingInfo){
+            // If no exact match, return all available platforms for this meeting_id
+            $availablePlatforms = $meetings->pluck('location')->unique()->values()->toArray();
+            return response()->json([
+                'error' => 'Meeting platform mismatch',
+                'message' => "Meeting found but platform '{$meetingPlatform}' does not match",
+                'available_platforms' => $availablePlatforms,
+                'meeting_id' => $meetingId
+            ], 400);
+        }
+        
+        $meeting['deal_id'] = $meetingInfo->deal_id;
+        $meeting['meeting_type_id'] = $meetingInfo->meeting_type_id;
+        $meeting['location'] = $meetingInfo->location;
+        return $meeting;
+    }
+}

--- a/app/Http/Controllers/MeetingSummaryController.php
+++ b/app/Http/Controllers/MeetingSummaryController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MeetingSummary;
+use App\Models\LeadFollowUp;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class MeetingSummaryController extends Controller
+{
+    /**
+     * Store a new meeting summary
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'summary_object' => 'required|array',
+            'meeting_type_id' => 'nullable|integer|exists:meeting_types,id',
+            'deal_id' => 'nullable|integer|exists:deals,id',
+            'meeting_id' => 'nullable|string'
+        ]);
+
+        $meetingSummary = MeetingSummary::create([
+            'summary_object' => $request->summary_object,
+            'meeting_type_id' => $request->meeting_type_id,
+            'deal_id' => $request->deal_id,
+        ]);
+
+        // If meeting_id is provided, update the lead_follow_up record
+        if ($request->meeting_id) {
+            $leadFollowUp = LeadFollowUp::where('meeting_id', $request->meeting_id)->first();
+            if ($leadFollowUp) {
+                $leadFollowUp->update(['summary_id' => $meetingSummary->id]);
+            }
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Meeting summary saved successfully',
+            'data' => $meetingSummary
+        ], 201);
+    }
+
+    /**
+     * Get meeting summary by ID
+     */
+    public function show($id): JsonResponse
+    {
+        $meetingSummary = MeetingSummary::with(['meetingType', 'deal'])->findOrFail($id);
+
+        return response()->json([
+            'success' => true,
+            'data' => $meetingSummary
+        ]);
+    }
+
+    /**
+     * Update meeting summary
+     */
+    public function update(Request $request, $id): JsonResponse
+    {
+        $request->validate([
+            'summary_object' => 'sometimes|array',
+            'meeting_type_id' => 'sometimes|integer|exists:meeting_types,id',
+            'deal_id' => 'sometimes|integer|exists:deals,id',
+        ]);
+
+        $meetingSummary = MeetingSummary::findOrFail($id);
+        $meetingSummary->update($request->only(['summary_object', 'meeting_type_id', 'deal_id']));
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Meeting summary updated successfully',
+            'data' => $meetingSummary
+        ]);
+    }
+
+    /**
+     * Delete meeting summary
+     */
+    public function destroy($id): JsonResponse
+    {
+        $meetingSummary = MeetingSummary::findOrFail($id);
+        $meetingSummary->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Meeting summary deleted successfully'
+        ]);
+    }
+
+    /**
+     * Get meeting summary by meeting ID
+     */
+    public function getByMeetingId($meetingId): JsonResponse
+    {
+        $leadFollowUp = LeadFollowUp::where('meeting_id', $meetingId)->first();
+        
+        if (!$leadFollowUp || !$leadFollowUp->summary_id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Meeting summary not found'
+            ], 404);
+        }
+
+        $meetingSummary = MeetingSummary::with(['meetingType', 'deal'])->find($leadFollowUp->summary_id);
+
+        return response()->json([
+            'success' => true,
+            'data' => $meetingSummary
+        ]);
+    }
+}

--- a/app/Models/DealFollowUp.php
+++ b/app/Models/DealFollowUp.php
@@ -30,6 +30,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @method static \Illuminate\Database\Eloquent\Builder|DealFollowUp whereUpdatedAt($value)
  * @property string|null $event_id
  * @method static \Illuminate\Database\Eloquent\Builder|DealFollowUp whereEventId($value)
+ * @property string|null $meeting_id
+ * @method static \Illuminate\Database\Eloquent\Builder|DealFollowUp whereMeetingId($value)
  * @property string|null $send_reminder
  * @property string|null $remind_time
  * @property string|null $remind_type
@@ -47,6 +49,25 @@ class DealFollowUp extends BaseModel
 {
 
     protected $table = 'lead_follow_up';
+
+    protected $fillable = [
+        'deal_id',
+        'meeting_type_id',
+        'location',
+        'meeting_link',
+        'remark',
+        'meeting_type',
+        'next_follow_up_date',
+        'added_by',
+        'last_updated_by',
+        'event_id',
+        'meeting_id',
+        'summary_id',
+        'send_reminder',
+        'remind_time',
+        'remind_type',
+        'status',
+    ];
 
     protected $casts = [
         'next_follow_up_date' => 'datetime',

--- a/app/Models/MeetingSummary.php
+++ b/app/Models/MeetingSummary.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class MeetingSummary extends Model
+{
+    use HasFactory;
+
+    protected $table = 'meeting_summary';
+
+    protected $fillable = [
+        'summary_object',
+        'meeting_type_id',
+        'deal_id',
+    ];
+
+    protected $casts = [
+        'summary_object' => 'array',
+    ];
+
+    public function meetingType(): BelongsTo
+    {
+        return $this->belongsTo(MeetingType::class, 'meeting_type_id');
+    }
+
+    public function deal(): BelongsTo
+    {
+        return $this->belongsTo(Deal::class, 'deal_id');
+    }
+}

--- a/app/Models/MeetingType.php
+++ b/app/Models/MeetingType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class MeetingType extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'color',
+        'company_id',
+    ];
+
+    public function meetingSummaries(): HasMany
+    {
+        return $this->hasMany(MeetingSummary::class, 'meeting_type_id');
+    }
+}

--- a/app/Observers/LeadFollowUpObserver.php
+++ b/app/Observers/LeadFollowUpObserver.php
@@ -84,7 +84,7 @@ class LeadFollowUpObserver
         $google = new Google();
         $googleAccount = company();
 
-        if (company()->google_calendar_status == 'active' && $googleAccount->google_calendar_verification_status == 'verified' && $googleAccount->token) {
+        if ($googleAccount && $googleAccount->google_calendar_status == 'active' && $googleAccount->google_calendar_verification_status == 'verified' && $googleAccount->token) {
             $google->connectUsing($googleAccount->token);
             try {
                 if ($leadFollowUp->event_id) {
@@ -118,7 +118,7 @@ class LeadFollowUpObserver
         $googleAccount = company();
         $module = GoogleCalendarModule::first();
 
-        if (company()->google_calendar_status == 'active' && $googleAccount->google_calendar_verification_status == 'verified' && $googleAccount->token && $module->lead_status == 1) {
+        if ($googleAccount && $googleAccount->google_calendar_status == 'active' && $googleAccount->google_calendar_verification_status == 'verified' && $googleAccount->token && $module->lead_status == 1) {
             $google = new Google();
             $attendiesData = [];
 

--- a/database/migrations/2025_09_27_131159_add_meeting_id_to_lead_follow_up_table.php
+++ b/database/migrations/2025_09_27_131159_add_meeting_id_to_lead_follow_up_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lead_follow_up', function (Blueprint $table) {
+            $table->string('meeting_id')->nullable()->after('event_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lead_follow_up', function (Blueprint $table) {
+            $table->dropColumn('meeting_id');
+        });
+    }
+};

--- a/database/migrations/2025_09_27_135046_create_meeting_summary_table.php
+++ b/database/migrations/2025_09_27_135046_create_meeting_summary_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('meeting_summary', function (Blueprint $table) {
+            $table->id();
+            $table->json('summary_object')->nullable();
+            $table->unsignedBigInteger('meeting_type_id')->nullable();
+            $table->unsignedBigInteger('deal_id')->nullable();
+            $table->timestamps();
+            
+            $table->foreign('meeting_type_id')->references('id')->on('meeting_types')->onDelete('set null');
+            $table->foreign('deal_id')->references('id')->on('deals')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('meeting_summary');
+    }
+};

--- a/database/migrations/2025_09_27_135105_add_summary_id_to_lead_follow_up_table.php
+++ b/database/migrations/2025_09_27_135105_add_summary_id_to_lead_follow_up_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lead_follow_up', function (Blueprint $table) {
+            $table->unsignedBigInteger('summary_id')->nullable()->after('meeting_id');
+            $table->foreign('summary_id')->references('id')->on('meeting_summary')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lead_follow_up', function (Blueprint $table) {
+            $table->dropForeign(['summary_id']);
+            $table->dropColumn('summary_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ ApiRoute::group(['namespace' => 'App\Http\Controllers'], function () {
         ApiRoute::get('deals/{dealId}/communication-activities', ['as' => 'api.deals.communication-activities', 'uses' => 'CommunicationActivityController@getDealActivities']);
         ApiRoute::get('leads/{leadId}/communication-activities', ['as' => 'api.leads.communication-activities', 'uses' => 'CommunicationActivityController@getLeadActivities']);
         ApiRoute::get('communication-activities/channel/{channelType}', ['as' => 'api.communication-activities.by-channel', 'uses' => 'CommunicationActivityController@getActivitiesByChannel']);
+        ApiRoute::post('meeting-summary', ['as' => 'api.meeting-summary', 'uses' => 'MeetingSummaryApiController@getMeetingSummary']);
 
     });
 });


### PR DESCRIPTION
- Add MeetingSummaryApiController with create/update functionality
- Add MeetingSummary and MeetingType models
- Update DealFollowUp model with meeting fields
- Add database migrations for meeting_summary table and fields
- Fix API exception handler undefined variable issue
- Fix LeadFollowUpObserver company() null reference errors
- Add platform validation for meeting matching
- Support both creating new and updating existing summaries
- Add proper error handling and response messages