### PR TITLE
Developer/Project/Product Link

### DIFF
--- a/app/Models/Developer.php
+++ b/app/Models/Developer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Developer extends Model
+{
+    use HasFactory;
+    // Fillable fields
+    protected $fillable = [
+        'company_id',
+        'name',
+        'logo',
+        'description',
+    ];
+    // Relationships
+    public function projects(): HasMany 
+    {
+        return $this->hasMany(DeveloperProject::class);
+    }
+}

--- a/app/Models/DeveloperProject.php
+++ b/app/Models/DeveloperProject.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DeveloperProject extends Model
+{
+    use HasFactory;
+
+    // Fillable fields
+    protected $fillable = [
+        'company_id',
+        'name',
+        'description',
+        'images',
+        'developer_id',
+    ];
+
+    // Casts
+    protected $casts = [
+        'images' => 'array',
+    ];
+
+    // Relationships
+    public function developer(): BelongsTo
+    {
+        return $this->belongsTo(Developer::class);
+    }
+}

--- a/database/migrations/2025_09_30_135223_create_developers_table.php
+++ b/database/migrations/2025_09_30_135223_create_developers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        Schema::create('developers', function (Blueprint $table) {
+            $table->id();
+            // company_id
+            $table->integer('company_id')->unsigned()->index();
+            $table->foreign('company_id', 'developers_company_id_fk')
+                ->references('id')
+                ->on('companies')
+                ->onDelete('cascade');
+            // name, logo, description
+            $table->string('name');
+            $table->string('logo')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('developers');
+    }
+};

--- a/database/migrations/2025_09_30_135814_create_developer_projects_table.php
+++ b/database/migrations/2025_09_30_135814_create_developer_projects_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        Schema::create('developer_projects', function (Blueprint $table) {
+            $table->id();
+            // company_id
+            $table->integer('company_id')->unsigned()->index();
+            $table->foreign('company_id', 'developer_projects_company_id_fk')
+                ->references('id')
+                ->on('companies')
+                ->onDelete('cascade');
+            //name, description, images, developer_id
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->json('images')->nullable();
+            $table->foreignId('developer_id')->constrained('developers')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('developer_projects');
+    }
+};

--- a/database/migrations/2025_09_30_143754_adds_project_id_to_products_table.php
+++ b/database/migrations/2025_09_30_143754_adds_project_id_to_products_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            // add project_id
+            $table->foreignId('developer_project_id')->nullable()->constrained('developer_projects')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION

This PR introduces two new models, **Developer** and **DeveloperProject**, along with their respective migrations. These models are intended to support managing developer entities and their associated projects.

Additionally, the **products** table has been updated to include a `developer_project_id` column, establishing a relationship between products and developer projects.

### Changes

* Added `Developer` model and migration.
* Added `DeveloperProject` model and migration.
* Updated `products` table to include `developer_project_id`.
* Defined relationships between `Product`, `Developer`, and `DeveloperProject`.

### Impact

This update enables products to be linked to specific developer projects, supporting upcoming features around property and developer management.

