### PR TITLE
fix: Standardize motivation field across DealContactApiController, Im…

### DIFF
--- a/app/Http/Controllers/Api/DealContactApiController.php
+++ b/app/Http/Controllers/Api/DealContactApiController.php
@@ -683,7 +683,7 @@ class DealContactApiController extends Controller
     {
         $hibarrFields = [
             'budget_range' => $request->input('customerBudget') ?? '',
-            'motivation/comment' => $request->input('motivation') ?? '',
+            'motivation' => $request->input('motivation') ?? '',
         ];
 
         HibarrDealFields::updateOrCreate(

--- a/app/Jobs/ImportDealJob.php
+++ b/app/Jobs/ImportDealJob.php
@@ -692,7 +692,7 @@ class ImportDealJob implements ShouldQueue
         // Map of column names to Hibarr field names
         $hibarrFields = [
             'interested_in' => 'interested_in',
-            'motivation/comment' => 'motivation/comment',
+            'motivation' => 'motivation',
             'purchase_timeline' => 'purchase_timeline',
             'budget_range' => 'budget_range',
             'strategy_meeting_booked' => 'strategy_meeting_booked',

--- a/app/Models/HibarrDealFields.php
+++ b/app/Models/HibarrDealFields.php
@@ -12,7 +12,7 @@ class HibarrDealFields extends Model
     [
         'deal_id',
         'interested_in',
-        'motivation/comment',
+        'motivation',
         'purchase_timeline',
         'budget_range',
         'strategy_meeting_booked',


### PR DESCRIPTION
…portDealJob, and HibarrDealFields model

- Updated the 'motivation' field to remove the '/comment' suffix for consistency across the application.
- Ensured that the changes are reflected in the relevant controller and model to maintain proper data handling.