### PR TITLE
feat: Add migration to conditionally add location and meeting_link co…

### DIFF
--- a/database/migrations/2025_11_28_120000_add_location_to_lead_follow_up_table_if_not_exists.php
+++ b/database/migrations/2025_11_28_120000_add_location_to_lead_follow_up_table_if_not_exists.php
@@ -11,17 +11,24 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('lead_follow_up', function (Blueprint $table) {
-            // Check if location column exists, if not add it
-            if (!Schema::hasColumn('lead_follow_up', 'location')) {
-                $table->string('location')->nullable()->before('deal_id');
-            }
-            
-            // Also check for meeting_link as it's often added together
-            if (!Schema::hasColumn('lead_follow_up', 'meeting_link')) {
-                $table->string('meeting_link')->nullable()->after('location');
-            }
-        });
+        // Check for column existence outside the Schema::table() closure
+        $needsLocation = !Schema::hasColumn('lead_follow_up', 'location');
+        $needsMeetingLink = !Schema::hasColumn('lead_follow_up', 'meeting_link');
+        
+        // Only modify the table if columns need to be added
+        if ($needsLocation || $needsMeetingLink) {
+            Schema::table('lead_follow_up', function (Blueprint $table) use ($needsLocation, $needsMeetingLink) {
+                // Add location column before deal_id if it doesn't exist
+                if ($needsLocation) {
+                    $table->string('location')->nullable()->before('deal_id');
+                }
+                
+                // Add meeting_link column after location if it doesn't exist
+                if ($needsMeetingLink) {
+                    $table->string('meeting_link')->nullable()->after('location');
+                }
+            });
+        }
     }
 
     /**
@@ -29,16 +36,23 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('lead_follow_up', function (Blueprint $table) {
-            // Only drop the columns if they exist
-            if (Schema::hasColumn('lead_follow_up', 'meeting_link')) {
-                $table->dropColumn('meeting_link');
-            }
-            
-            if (Schema::hasColumn('lead_follow_up', 'location')) {
-                $table->dropColumn('location');
-            }
-        });
+        // Check for column existence outside the Schema::table() closure
+        $hasMeetingLink = Schema::hasColumn('lead_follow_up', 'meeting_link');
+        $hasLocation = Schema::hasColumn('lead_follow_up', 'location');
+        
+        // Only modify the table if at least one column needs dropping
+        if ($hasMeetingLink || $hasLocation) {
+            Schema::table('lead_follow_up', function (Blueprint $table) use ($hasMeetingLink, $hasLocation) {
+                // Drop meeting_link first, then location (preserve existing drop order)
+                if ($hasMeetingLink) {
+                    $table->dropColumn('meeting_link');
+                }
+                
+                if ($hasLocation) {
+                    $table->dropColumn('location');
+                }
+            });
+        }
     }
 };
 


### PR DESCRIPTION
…lumns to lead_follow_up table

- Introduced a new migration that checks for the existence of 'location' and 'meeting_link' columns in the lead_follow_up table and adds them if they do not exist.
- Ensured that the down method properly drops these columns if they were added during the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Database Updates**
  * Added support for storing a location and meeting link on lead follow-ups to enable richer follow-up details.
  * Migration now includes safety checks to apply or revert these schema changes only when needed, reducing deployment risk.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->