### PR TITLE
Hib 339 redesign lead deal detail views

### DIFF
--- a/resources/js/Components/CustomFieldDisplay.tsx
+++ b/resources/js/Components/CustomFieldDisplay.tsx
@@ -1,5 +1,4 @@
 import {
-    Descriptions,
     Tag,
     Upload,
     Button,
@@ -8,6 +7,7 @@ import {
     Tooltip,
     Progress,
 } from "antd";
+import { DetailSection, DetailField } from "@/Components/DetailSection";
 import {
     UploadOutlined,
     DeleteOutlined,
@@ -1539,7 +1539,7 @@ export default function CustomFieldDisplay({
     }
 
     return (
-        <Descriptions column={column} bordered size="middle">
+        <DetailSection gridClassName="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-5">
             {filteredFields.map((field) => {
                 const fieldKey = `field_${field.id}`;
                 const value =
@@ -1548,19 +1548,15 @@ export default function CustomFieldDisplay({
                 const span = calculateSpan(field, value);
 
                 return (
-                    <Descriptions.Item
+                    <DetailField
                         key={field.id}
-                        label={
-                            <div className="max-w-[120px] sm:max-w-[150px] whitespace-normal break-words leading-tight">
-                                {field.label}
-                            </div>
-                        }
-                        span={span}
+                        label={field.label}
+                        span={span === column ? 2 : 1}
                     >
                         {renderEditable(field, value)}
-                    </Descriptions.Item>
+                    </DetailField>
                 );
             })}
-        </Descriptions>
+        </DetailSection>
     );
 }

--- a/resources/js/Components/DetailSection.tsx
+++ b/resources/js/Components/DetailSection.tsx
@@ -1,4 +1,16 @@
-import React from "react";
+import React, { createContext, useState, useCallback } from "react";
+import { EditOutlined } from "@ant-design/icons";
+
+// ─── DetailFieldEditContext ────────────────────────────────────────────────────
+// Lets a child EditableField register its startEditing fn so the parent
+// DetailField can show the edit icon next to the label on hover.
+
+interface DetailFieldEditContextValue {
+    setEditHandler: (fn: (() => void) | null) => void;
+}
+
+export const DetailFieldEditContext =
+    createContext<DetailFieldEditContextValue | null>(null);
 
 // ─── DetailSection ─────────────────────────────────────────────────────────────
 // A white, bordered card with an optional section heading.
@@ -51,18 +63,39 @@ export function DetailField({
     span = 1,
     className = "",
 }: DetailFieldProps) {
+    // editHandler is registered by a child EditableField via context
+    const [editHandler, setEditHandlerState] = useState<(() => void) | null>(null);
+
+    // Stable setter so the child effect doesn't cause re-render loops
+    const setEditHandler = useCallback((fn: (() => void) | null) => {
+        setEditHandlerState(() => fn ?? null);
+    }, []);
+
     return (
-        <div
-            className={`flex flex-col gap-1 min-w-0 ${
-                span === 2 ? "sm:col-span-2" : ""
-            } ${className}`}
-        >
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 leading-none">
-                {label}
-            </span>
-            <div className="text-sm text-gray-800 break-words min-h-[1.5rem] flex items-start">
-                {children}
+        <DetailFieldEditContext.Provider value={{ setEditHandler }}>
+            <div
+                className={`group flex flex-col gap-1 min-w-0 ${
+                    span === 2 ? "sm:col-span-2" : ""
+                } ${className}`}
+            >
+                {/* Label row — edit pencil appears here on group hover */}
+                <div className="flex items-center gap-1">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 leading-none">
+                        {label}
+                    </span>
+                    {editHandler && (
+                        <EditOutlined
+                            className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity text-[10px] cursor-pointer"
+                            onClick={() => editHandler()}
+                        />
+                    )}
+                </div>
+
+                {/* Value area — full width, no truncation */}
+                <div className="text-sm text-gray-800 min-h-[1.5rem]">
+                    {children}
+                </div>
             </div>
-        </div>
+        </DetailFieldEditContext.Provider>
     );
 }

--- a/resources/js/Components/DetailSection.tsx
+++ b/resources/js/Components/DetailSection.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+// ─── DetailSection ─────────────────────────────────────────────────────────────
+// A white, bordered card with an optional section heading.
+// Fields are laid out in a 2-column grid by default.
+
+interface DetailSectionProps {
+    title?: string;
+    children: React.ReactNode;
+    className?: string;
+    /** Allow callers to override the inner grid class (e.g. for 1-col layouts) */
+    gridClassName?: string;
+}
+
+export function DetailSection({
+    title,
+    children,
+    className = "",
+    gridClassName = "grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-5",
+}: DetailSectionProps) {
+    return (
+        <div
+            className={`bg-white border border-gray-100 rounded-xl overflow-hidden mb-4 last:mb-0 ${className}`}
+        >
+            {title && (
+                <div className="px-5 py-3 border-b border-gray-100 bg-gray-50/80">
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                        {title}
+                    </h3>
+                </div>
+            )}
+            <div className={`px-5 py-4 ${gridClassName}`}>{children}</div>
+        </div>
+    );
+}
+
+// ─── DetailField ──────────────────────────────────────────────────────────────
+// A label + value cell that lives inside a DetailSection grid.
+
+interface DetailFieldProps {
+    label: string;
+    children: React.ReactNode;
+    /** When 2, the field spans the full row (both columns) */
+    span?: 1 | 2;
+    className?: string;
+}
+
+export function DetailField({
+    label,
+    children,
+    span = 1,
+    className = "",
+}: DetailFieldProps) {
+    return (
+        <div
+            className={`flex flex-col gap-1 min-w-0 ${
+                span === 2 ? "sm:col-span-2" : ""
+            } ${className}`}
+        >
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 leading-none">
+                {label}
+            </span>
+            <div className="text-sm text-gray-800 break-words min-h-[1.5rem] flex items-start">
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/Components/EditableField.tsx
+++ b/resources/js/Components/EditableField.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useContext } from "react";
 import {
     Input,
     Typography,
@@ -26,6 +26,7 @@ import { FormDataType } from "@/Hooks/useFormData";
 import { usePage } from "@inertiajs/react";
 import CurrencyInput from "./CurrencyInput";
 import { parsePropertyPrice, formatCurrencyWithSymbol, formatCountryForDisplay, formatMobileForDisplay } from "@/lib/utils";
+import { DetailFieldEditContext } from "./DetailSection";
 
 const { Text } = Typography;
 
@@ -262,6 +263,24 @@ export default function EditableField({
             setInputValue(normalizedValue ?? "");
         }
     };
+
+    // Keep a stable ref to startEditing so the context registration never goes stale
+    const startEditingRef = useRef(startEditing);
+    startEditingRef.current = startEditing;
+
+    // Register/unregister with the nearest parent DetailField via context
+    const detailFieldCtx = useContext(DetailFieldEditContext);
+    useEffect(() => {
+        if (!detailFieldCtx) return;
+        if (canStartEditing && !editing) {
+            detailFieldCtx.setEditHandler(() => startEditingRef.current());
+        } else {
+            detailFieldCtx.setEditHandler(null);
+        }
+        return () => {
+            detailFieldCtx.setEditHandler(null);
+        };
+    }, [detailFieldCtx, canStartEditing, editing]);
 
     const handleSave = async () => {
         // Clear any pending blur timeout to prevent double save
@@ -841,23 +860,12 @@ export default function EditableField({
     return (
         <Skeleton active loading={loading || saving} paragraph={{ rows: 1 }}>
             <div
-                className={`group flex items-center justify-between gap-2 px-2 py-1 rounded transition-colors ${
-                    canStartEditing ? "hover:bg-gray-50 cursor-pointer" : ""
-                } ${
+                className={`w-full px-2 py-1 ${
                     isLocked ? "cursor-not-allowed opacity-50" : ""
                 } ${className}`}
                 onDoubleClick={canStartEditing ? startEditing : undefined}
             >
-                <Text className="flex-1 break-words">{displayText}</Text>
-                {canStartEditing && (
-                    <EditOutlined
-                        className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            startEditing();
-                        }}
-                    />
-                )}
+                <span className="break-words whitespace-normal">{displayText}</span>
             </div>
         </Skeleton>
     );

--- a/resources/js/Components/FieldRenderer.tsx
+++ b/resources/js/Components/FieldRenderer.tsx
@@ -1,0 +1,73 @@
+/**
+ * FieldRenderer
+ *
+ * Maps a dynamic array of `CustomField` objects (typed from @/Types) plus stored
+ * values into a grid of `DetailSection`/`DetailField` cells.
+ *
+ * This is a thin, strongly-typed façade over `CustomFieldDisplay` which owns all
+ * the per-field-type rendering and visibility-rule evaluation logic. Using this
+ * component in detail views keeps the call-site clean and decoupled from the
+ * internal `Field` interface used by `CustomFieldDisplay`.
+ */
+import React from "react";
+import { type CustomField } from "@/Types";
+import CustomFieldDisplay from "./CustomFieldDisplay";
+
+interface FieldRendererProps {
+    fields: CustomField[];
+    values: Record<string, any>;
+    /** When true all fields render as inputs; false = read-only labels */
+    isEditing?: boolean;
+    /** Called when a field value changes (pending-changes tracking) */
+    onChange?: (fieldName: string, value: any) => void;
+    /** Called to persist a single field value immediately */
+    onSave?: (fieldName: string, value: any) => Promise<void>;
+    /** The field currently being saved (shows per-field loading indicator) */
+    loadingField?: string | null;
+    /** When true all fields are disabled (saving-all in progress) */
+    globalLoading?: boolean;
+    /** When true, editing is disabled regardless of isEditing */
+    disabled?: boolean;
+    /** Restrict to a specific category id */
+    categoryId?: string | number;
+}
+
+export default function FieldRenderer({
+    fields,
+    values,
+    isEditing = false,
+    onChange,
+    onSave,
+    loadingField,
+    globalLoading,
+    disabled,
+    categoryId,
+}: FieldRendererProps) {
+    // Convert typed CustomField[] to the shape CustomFieldDisplay expects for `fields`
+    const adaptedFields = fields.map((f) => ({
+        id: f.id,
+        label: f.label,
+        type: f.type,
+        values: f.values ?? undefined,
+        custom_field_category_id: f.custom_field_group_id,
+        show_rule_set: f.show_rule_set,
+        linked_field_id: f.linked_field_id ?? undefined,
+        display_config: f.display_config ?? undefined,
+    }));
+
+    return (
+        <CustomFieldDisplay
+            fields={adaptedFields}
+            customFieldsData={values}
+            categoryId={categoryId}
+            column={2}
+            onUpdate={onSave}
+            editable={isEditing}
+            alwaysEditing={isEditing}
+            onChange={onChange}
+            loadingField={loadingField ?? null}
+            globalLoading={globalLoading}
+            disabled={disabled}
+        />
+    );
+}

--- a/resources/js/Pages/Deals/Components/DealDetailsTab.tsx
+++ b/resources/js/Pages/Deals/Components/DealDetailsTab.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Deal, HibarrDealFields } from "@/Types/api/deals";
-import { Descriptions, Tag } from "antd";
+import { Tag } from "antd";
 import { CheckCircleOutlined, CloseCircleOutlined } from "@ant-design/icons";
 import dayjs from "dayjs";
 import EditableField from "@/Components/EditableField";
+import { DetailSection, DetailField } from "@/Components/DetailSection";
 
 interface Props {
     deal: Deal;
@@ -55,13 +56,9 @@ const DealDetailsTab: React.FC<Props> = ({
     };
 
     return (
-        <div className="p-6">
-            <Descriptions
-                column={{ xxl: 2, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 }}
-                bordered
-                size="middle"
-            >
-                <Descriptions.Item label="Interested In">
+        <div className="p-4 space-y-4">
+            <DetailSection title="Interest & Budget">
+                <DetailField label="Interested In">
                     <EditableField
                         value={fields.interested_in}
                         fieldName="interested_in"
@@ -72,22 +69,9 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("interested_in")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
 
-                <Descriptions.Item label="Budget Range">
-                    <EditableField
-                        value={fields.budget_range}
-                        fieldName="budget_range"
-                        fieldType="text"
-                        onSave={(value) => handleSave("budget_range", value)}
-                        alwaysEditing={editable}
-                        onChange={onChange}
-                        loading={isFieldLoading("budget_range")}
-                        disabled={disabled}
-                    />
-                </Descriptions.Item>
-
-                <Descriptions.Item label="Purchase Timeline">
+                <DetailField label="Purchase Timeline">
                     <EditableField
                         value={fields.purchase_timeline}
                         fieldName="purchase_timeline"
@@ -100,9 +84,9 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("purchase_timeline")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
 
-                <Descriptions.Item label="Motivation">
+                <DetailField label="Motivation" span={2}>
                     <EditableField
                         value={fields.motivation}
                         fieldName="motivation"
@@ -113,9 +97,11 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("motivation")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
+            </DetailSection>
 
-                <Descriptions.Item label="Strategy Meeting Booked">
+            <DetailSection title="Progress">
+                <DetailField label="Strategy Meeting Booked">
                     <EditableField
                         value={fields.strategy_meeting_booked ? 1 : 0}
                         fieldName="strategy_meeting_booked"
@@ -131,9 +117,9 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("strategy_meeting_booked")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
 
-                <Descriptions.Item label="Downpayment Paid">
+                <DetailField label="Downpayment Paid">
                     <EditableField
                         value={fields.downpayment_paid ? 1 : 0}
                         fieldName="downpayment_paid"
@@ -147,9 +133,9 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("downpayment_paid")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
 
-                <Descriptions.Item label="Inspection Trip Date">
+                <DetailField label="Inspection Trip Date">
                     <EditableField
                         value={fields.inspection_trip_date}
                         fieldName="inspection_trip_date"
@@ -165,9 +151,9 @@ const DealDetailsTab: React.FC<Props> = ({
                             val ? dayjs(val).format("MMM DD, YYYY") : "--"
                         }
                     />
-                </Descriptions.Item>
+                </DetailField>
 
-                <Descriptions.Item label="Deposit Confirmation">
+                <DetailField label="Deposit Confirmation">
                     <EditableField
                         value={fields.deposit_confirmation}
                         fieldName="deposit_confirmation"
@@ -180,9 +166,11 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("deposit_confirmation")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
+            </DetailSection>
 
-                <Descriptions.Item label="Reservation Agreement">
+            <DetailSection title="Documentation">
+                <DetailField label="Reservation Agreement">
                     <EditableField
                         value={fields.reservation_agreement}
                         fieldName="reservation_agreement"
@@ -195,9 +183,9 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("reservation_agreement")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
+                </DetailField>
 
-                <Descriptions.Item label="Sales Contract">
+                <DetailField label="Sales Contract">
                     <EditableField
                         value={fields.sales_contract}
                         fieldName="sales_contract"
@@ -208,8 +196,11 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("sales_contract")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
-                <Descriptions.Item label="Message">
+                </DetailField>
+            </DetailSection>
+
+            <DetailSection title="Notes" gridClassName="grid grid-cols-1">
+                <DetailField label="Message" span={2}>
                     <EditableField
                         value={fields.message}
                         fieldName="message"
@@ -220,8 +211,8 @@ const DealDetailsTab: React.FC<Props> = ({
                         loading={isFieldLoading("message")}
                         disabled={disabled}
                     />
-                </Descriptions.Item>
-            </Descriptions>
+                </DetailField>
+            </DetailSection>
         </div>
     );
 };

--- a/resources/js/Pages/Deals/Components/DealInfoSection.tsx
+++ b/resources/js/Pages/Deals/Components/DealInfoSection.tsx
@@ -466,59 +466,58 @@ export default function DealInfoSection({
         // Toggle edit mode button - only show if user can edit
         ...(canEdit && !isEditMode
             ? [
-                  {
-                      key: "edit",
-                      icon: <EditOutlined />,
-                      tooltip: "Edit Deal",
-                      type: "text" as const,
-                      onClick: handleToggleEditMode,
-                  },
-              ]
+                {
+                    key: "edit",
+                    icon: <EditOutlined />,
+                    tooltip: "Edit Deal",
+                    type: "text" as const,
+                    onClick: handleToggleEditMode,
+                },
+            ]
             : []),
         // Save all button - only show when in edit mode with changes
         ...(isEditMode
             ? [
-                  {
-                      key: "save_all",
-                      icon: <SaveOutlined />,
-                      tooltip: hasUnsavedChanges
-                          ? `Save All Changes (${
-                                Object.keys(pendingChanges).length
-                            })`
-                          : "No changes to save",
-                      type: "primary" as const,
-                      onClick: handleSaveAll,
-                      disabled: !hasUnsavedChanges || isSavingAll,
-                      loading: isSavingAll,
-                  },
-              ]
+                {
+                    key: "save_all",
+                    icon: <SaveOutlined />,
+                    tooltip: hasUnsavedChanges
+                        ? `Save All Changes (${Object.keys(pendingChanges).length
+                        })`
+                        : "No changes to save",
+                    type: "primary" as const,
+                    onClick: handleSaveAll,
+                    disabled: !hasUnsavedChanges || isSavingAll,
+                    loading: isSavingAll,
+                },
+            ]
             : []),
         // Cancel edit mode button - only show when in edit mode
         ...(isEditMode
             ? [
-                  {
-                      key: "cancel_edit",
-                      icon: <CloseOutlined />,
-                      tooltip: "Cancel Edit",
-                      type: "text" as const,
-                      onClick: handleExitEditMode,
-                  },
-              ]
+                {
+                    key: "cancel_edit",
+                    icon: <CloseOutlined />,
+                    tooltip: "Cancel Edit",
+                    type: "text" as const,
+                    onClick: handleExitEditMode,
+                },
+            ]
             : []),
         // Only show delete button if user can delete
         ...(canDelete
             ? [
-                  {
-                      key: "delete",
-                      icon: <DeleteOutlined />,
-                      tooltip: "Delete Deal",
-                      type: "text" as const,
-                      danger: true,
-                      onClick: () => {
-                          handleAction("delete");
-                      },
-                  },
-              ]
+                {
+                    key: "delete",
+                    icon: <DeleteOutlined />,
+                    tooltip: "Delete Deal",
+                    type: "text" as const,
+                    danger: true,
+                    onClick: () => {
+                        handleAction("delete");
+                    },
+                },
+            ]
             : []),
     ];
 
@@ -613,8 +612,8 @@ export default function DealInfoSection({
                                 formatValue={(value) =>
                                     value
                                         ? dayjs(value.toString()).format(
-                                              "MMM DD, YYYY",
-                                          )
+                                            "MMM DD, YYYY",
+                                        )
                                         : "--"
                                 }
                                 alwaysEditing={isFieldEditable}
@@ -639,11 +638,11 @@ export default function DealInfoSection({
                                 displayValue={
                                     currentDeal.packages?.length
                                         ? currentDeal.packages
-                                              .map(
-                                                  (pkg: any) =>
-                                                      pkg?.name || pkg,
-                                              )
-                                              .join(", ")
+                                            .map(
+                                                (pkg: any) =>
+                                                    pkg?.name || pkg,
+                                            )
+                                            .join(", ")
                                         : "--"
                                 }
                                 onSave={(value) =>
@@ -702,6 +701,83 @@ export default function DealInfoSection({
                                 disabled={!canEdit}
                             />
                         </DetailField>
+
+                        <DetailField label="Deal Category">
+                            <EditableField
+                                value={currentDeal.category_id}
+                                fieldName="category_id"
+                                selectorType="categories"
+                                displayValue={
+                                    currentDeal.category?.category_name ? (
+                                        <Tag color="blue" className="font-medium">
+                                            {currentDeal.category.category_name}
+                                        </Tag>
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("category_id", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("category_id")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        <DetailField label="Properties" span={2}>
+                            <EditableField
+                                value={
+                                    currentDeal.products?.map(
+                                        (p: any) => p.id,
+                                    ) || []
+                                }
+                                fieldName="product_id"
+                                selectorType="products"
+                                mode="multiple"
+                                displayValue={
+                                    productNames.length > 0 ? (
+                                        <div className="flex flex-wrap gap-1">
+                                            {productNames.map(
+                                                (product, index) => (
+                                                    <Tag
+                                                        key={index}
+                                                        color="blue"
+                                                    >
+                                                        {product}
+                                                    </Tag>
+                                                ),
+                                            )}
+                                        </div>
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("product_id", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("product_id")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        {currentDeal?.lead_status && (
+                            <DetailField label="Status">
+                                <Tag
+                                    color={currentDeal.lead_status.label_color}
+                                    className="font-medium"
+                                >
+                                    {currentDeal.lead_status.type}
+                                </Tag>
+                            </DetailField>
+                        )}
                     </DetailSection>
 
                     {/* Contact Info */}
@@ -780,34 +856,8 @@ export default function DealInfoSection({
                         </DetailField>
                     </DetailSection>
 
-                    {/* Classification */}
-                    <DetailSection title="Classification">
-                        <DetailField label="Deal Category">
-                            <EditableField
-                                value={currentDeal.category_id}
-                                fieldName="category_id"
-                                selectorType="categories"
-                                displayValue={
-                                    currentDeal.category?.category_name ? (
-                                        <Tag color="blue" className="font-medium">
-                                            {currentDeal.category.category_name}
-                                        </Tag>
-                                    ) : (
-                                        <span className="text-gray-400">--</span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("category_id", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("category_id")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </DetailField>
-
+                    {/* Team */}
+                    <DetailSection title="Team">
                         <DetailField label="Deal Agent">
                             <EditableField
                                 value={currentDeal.agent_id}
@@ -818,6 +868,7 @@ export default function DealInfoSection({
                                         <UserIndicator
                                             data={currentDeal.lead_agent.user}
                                             size="sm"
+                                            maxNameLength={40}
                                         />
                                     ) : (
                                         <span className="text-gray-400">--</span>
@@ -834,21 +885,6 @@ export default function DealInfoSection({
                                 disabled={!canEdit}
                             />
                         </DetailField>
-
-                        {currentDeal?.lead_status && (
-                            <DetailField label="Status">
-                                <Tag
-                                    color={currentDeal.lead_status.label_color}
-                                    className="font-medium"
-                                >
-                                    {currentDeal.lead_status.type}
-                                </Tag>
-                            </DetailField>
-                        )}
-                    </DetailSection>
-
-                    {/* Team */}
-                    <DetailSection title="Team">
                         <DetailField label="Deal Watchers" span={2}>
                             <EditableField
                                 value={
@@ -861,7 +897,7 @@ export default function DealInfoSection({
                                 mode="multiple"
                                 displayValue={
                                     currentDeal.deal_watchers &&
-                                    currentDeal.deal_watchers.length > 0 ? (
+                                        currentDeal.deal_watchers.length > 0 ? (
                                         <MultiUserIndicator
                                             users={currentDeal.deal_watchers.map(
                                                 (watcher: any) => ({
@@ -905,7 +941,7 @@ export default function DealInfoSection({
                                 mode="multiple"
                                 displayValue={
                                     currentDeal.deal_participants &&
-                                    currentDeal.deal_participants.length > 0 ? (
+                                        currentDeal.deal_participants.length > 0 ? (
                                         <MultiUserIndicator
                                             users={currentDeal.deal_participants.map(
                                                 (participant: any) => ({
@@ -937,45 +973,7 @@ export default function DealInfoSection({
                             />
                         </DetailField>
 
-                        <DetailField label="Properties" span={2}>
-                            <EditableField
-                                value={
-                                    currentDeal.products?.map(
-                                        (p: any) => p.id,
-                                    ) || []
-                                }
-                                fieldName="product_id"
-                                selectorType="products"
-                                mode="multiple"
-                                displayValue={
-                                    productNames.length > 0 ? (
-                                        <div className="flex flex-wrap gap-1">
-                                            {productNames.map(
-                                                (product, index) => (
-                                                    <Tag
-                                                        key={index}
-                                                        color="blue"
-                                                    >
-                                                        {product}
-                                                    </Tag>
-                                                ),
-                                            )}
-                                        </div>
-                                    ) : (
-                                        <span className="text-gray-400">--</span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("product_id", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("product_id")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </DetailField>
+
                     </DetailSection>
                 </div>
             ),
@@ -1058,11 +1056,10 @@ export default function DealInfoSection({
             <div>
                 {/* Header */}
                 <div
-                    className={`flex items-center justify-between px-5 py-3 border-b ${
-                        isEditMode
+                    className={`flex items-center justify-between px-5 py-3 border-b ${isEditMode
                             ? "bg-blue-50 border-blue-100"
                             : "bg-gray-50/80 border-gray-100"
-                    }`}
+                        }`}
                 >
                     <div className="flex items-center gap-3">
                         <h2 className="text-sm font-semibold text-gray-700">

--- a/resources/js/Pages/Deals/Components/DealInfoSection.tsx
+++ b/resources/js/Pages/Deals/Components/DealInfoSection.tsx
@@ -1,7 +1,6 @@
 import { Deal } from "@/Types/api/deals";
 import { Link, router, usePage } from "@inertiajs/react";
 import {
-    Descriptions,
     Tag,
     Avatar,
     Tooltip,
@@ -38,6 +37,7 @@ import EditableField from "@/Components/EditableField";
 import { useApiMutate } from "@/lib/api/client/useApiMutate";
 import { ApiResponse } from "@/lib/api/types";
 import axios from "axios";
+import { DetailSection, DetailField } from "@/Components/DetailSection";
 
 interface Props {
     deal: Deal;
@@ -51,6 +51,8 @@ interface Props {
     taskBoardColumns: any[];
     employees: any[];
     projects: any[];
+    isEditMode: boolean;
+    onEditModeChange: (value: boolean) => void;
 }
 
 export default function DealInfoSection({
@@ -65,6 +67,8 @@ export default function DealInfoSection({
     taskBoardColumns,
     employees,
     projects,
+    isEditMode,
+    onEditModeChange,
 }: Props) {
     const { props } = usePage<any>();
     const user = props.auth.user;
@@ -74,9 +78,6 @@ export default function DealInfoSection({
     const { action, handleAction, handleClose } = useGenericEntityAction();
     const [currentDeal, setCurrentDeal] = useState<Deal>(deal);
     const [updatingField, setUpdatingField] = useState<string | null>(null);
-
-    // Edit mode state - when true, all fields become editable
-    const [isEditMode, setIsEditMode] = useState(false);
 
     // Track pending changes in edit mode
     const [pendingChanges, setPendingChanges] = useState<Record<string, any>>(
@@ -129,7 +130,7 @@ export default function DealInfoSection({
 
     // Toggle edit mode
     const handleToggleEditMode = () => {
-        setIsEditMode(!isEditMode);
+        onEditModeChange(!isEditMode);
         // Clear pending changes when entering edit mode
         if (!isEditMode) {
             setPendingChanges({});
@@ -138,7 +139,7 @@ export default function DealInfoSection({
 
     // Exit edit mode
     const handleExitEditMode = () => {
-        setIsEditMode(false);
+        onEditModeChange(false);
         setPendingChanges({});
     };
 
@@ -276,7 +277,7 @@ export default function DealInfoSection({
 
             message.success("All changes saved successfully");
             setPendingChanges({});
-            setIsEditMode(false);
+            onEditModeChange(false);
         } catch (error: any) {
             message.error(error?.message || "Failed to save changes");
         } finally {
@@ -527,9 +528,10 @@ export default function DealInfoSection({
             key: "overview",
             label: "Overview",
             children: (
-                <div className="p-6">
-                    <Descriptions column={2} bordered size="middle">
-                        <Descriptions.Item label="Deal Name" span={2}>
+                <div className="p-4 space-y-4">
+                    {/* Deal Overview */}
+                    <DetailSection title="Deal Overview">
+                        <DetailField label="Deal Name" span={2}>
                             <EditableField
                                 value={currentDeal.name}
                                 fieldName="name"
@@ -543,339 +545,9 @@ export default function DealInfoSection({
                                 onChange={handleFieldChange}
                                 disabled={!canEdit}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Package(s)">
-                            <EditableField
-                                value={
-                                    currentDeal.packages?.map(
-                                        (p: any) => p.id,
-                                    ) || []
-                                }
-                                fieldName="package_id"
-                                selectorType="packages"
-                                mode="multiple"
-                                displayValue={
-                                    currentDeal.packages?.length
-                                        ? currentDeal.packages
-                                              .map(
-                                                  (pkg: any) =>
-                                                      pkg?.name || pkg,
-                                              )
-                                              .join(", ")
-                                        : "--"
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("package_id", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("package_id")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Lead Contact">
-                            <EditableField
-                                value={currentDeal?.lead_id}
-                                fieldName="lead_id"
-                                selectorType="leads"
-                                displayValue={
-                                    currentDeal.contact ? (
-                                        <div className="space-y-1">
-                                            <Link
-                                                href={route(
-                                                    "lead-contact.show",
-                                                    currentDeal.contact.id,
-                                                )}
-                                                className="text-blue-600 hover:text-blue-800 font-medium"
-                                            >
-                                                {currentDeal.contact
-                                                    .client_name_salutation ||
-                                                    currentDeal.contact
-                                                        .client_name}
-                                            </Link>
-                                            {currentDeal.contact.client_id && (
-                                                <Tag
-                                                    color="blue"
-                                                    className="text-xs"
-                                                >
-                                                    Client
-                                                </Tag>
-                                            )}
-                                        </div>
-                                    ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("lead_id", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("lead_id")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Email">
-                            {currentDeal.contact?.client_email ? (
-                                <div className="flex items-center gap-x-2">
-                                    <MailOutlined className="text-gray-400" />
-                                    <EditableField
-                                        value={currentDeal.contact.client_email}
-                                        fieldName="email"
-                                        fieldType="email"
-                                        onSave={(value) =>
-                                            handleFieldUpdate("email", value)
-                                        }
-                                        className="text-blue-600 hover:text-blue-800"
-                                        alwaysEditing={isFieldEditable}
-                                        onChange={handleFieldChange}
-                                        loading={
-                                            isSavingAll ||
-                                            isFieldLoading("email")
-                                        }
-                                        disabled={!canEdit}
-                                    />
-                                </div>
-                            ) : (
-                                <span className="text-gray-500">--</span>
-                            )}
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Mobile">
-                            {currentDeal.contact ? (
-                                <div className="flex items-center gap-x-2">
-                                    <PhoneOutlined className="text-gray-400" />
-                                    <EditableField
-                                        value={getMobileNumber(
-                                            currentDeal.contact.mobile,
-                                        )}
-                                        fieldName="mobile"
-                                        fieldType="phone"
-                                        onSave={(value) =>
-                                            handleFieldUpdate("mobile", value)
-                                        }
-                                        alwaysEditing={isFieldEditable}
-                                        onChange={handleFieldChange}
-                                        loading={
-                                            isSavingAll ||
-                                            isFieldLoading("mobile")
-                                        }
-                                        disabled={!canEdit}
-                                    />
-                                </div>
-                            ) : (
-                                <span className="text-gray-500">--</span>
-                            )}
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Company Name">
-                            <EditableField
-                                value={currentDeal.contact?.company_name}
-                                fieldName="company_name"
-                                fieldType="text"
-                                onSave={(value) =>
-                                    handleFieldUpdate("company_name", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll ||
-                                    isFieldLoading("company_name")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Deal Category">
-                            <EditableField
-                                value={currentDeal.category_id}
-                                fieldName="category_id"
-                                selectorType="categories"
-                                displayValue={
-                                    currentDeal.category?.category_name || (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("category_id", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("category_id")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Deal Agent">
-                            <EditableField
-                                value={currentDeal.agent_id}
-                                fieldName="agent_id"
-                                selectorType="lead-agents"
-                                displayValue={
-                                    currentDeal.lead_agent?.user ? (
-                                        <UserIndicator
-                                            data={currentDeal.lead_agent.user}
-                                            size="sm"
-                                        />
-                                    ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("agent_id", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("agent_id")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Deal Watchers" span={2}>
-                            <EditableField
-                                value={
-                                    currentDeal.deal_watchers?.map(
-                                        (w: any) => w.id,
-                                    ) || []
-                                }
-                                fieldName="deal_watcher"
-                                selectorType="employees"
-                                mode="multiple"
-                                displayValue={
-                                    currentDeal.deal_watchers &&
-                                    currentDeal.deal_watchers.length > 0 ? (
-                                        <MultiUserIndicator
-                                            users={currentDeal.deal_watchers.map(
-                                                (watcher: any) => ({
-                                                    id: watcher.id,
-                                                    image_url:
-                                                        watcher.image_url ||
-                                                        watcher.image, // Handle both structures
-                                                    name: watcher.name,
-                                                }),
-                                            )}
-                                            size="sm"
-                                            maxCount={2}
-                                            showTooltip={true}
-                                        />
-                                    ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("deal_watcher", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll ||
-                                    isFieldLoading("deal_watcher")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Deal Participants" span={2}>
-                            <EditableField
-                                value={
-                                    currentDeal.deal_participants?.map(
-                                        (p: any) => p.id,
-                                    ) || []
-                                }
-                                fieldName="deal_participant"
-                                selectorType="employees"
-                                mode="multiple"
-                                displayValue={
-                                    currentDeal.deal_participants &&
-                                    currentDeal.deal_participants.length > 0 ? (
-                                        <MultiUserIndicator
-                                            users={currentDeal.deal_participants.map(
-                                                (participant: any) => ({
-                                                    id: participant.id,
-                                                    image_url:
-                                                        participant.image_url ||
-                                                        participant.image,
-                                                    name: participant.name,
-                                                }),
-                                            )}
-                                            size="sm"
-                                            maxCount={2}
-                                            showTooltip={true}
-                                        />
-                                    ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
-                                    )
-                                }
-                                onSave={(value) =>
-                                    handleFieldUpdate("deal_participant", value)
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll ||
-                                    isFieldLoading("deal_participant")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        {currentDeal?.lead_status && (
-                            <Descriptions.Item label="Status">
-                                <Tag
-                                    color={currentDeal.lead_status.label_color}
-                                    className="font-medium"
-                                >
-                                    {currentDeal.lead_status.type}
-                                </Tag>
-                            </Descriptions.Item>
-                        )}
-
-                        <Descriptions.Item label="Close Date">
-                            <EditableField
-                                value={currentDeal.close_date}
-                                fieldName="close_date"
-                                fieldType="date"
-                                onSave={(value) =>
-                                    handleFieldUpdate("close_date", value)
-                                }
-                                formatValue={(value) =>
-                                    value
-                                        ? dayjs(value.toString()).format(
-                                              "MMM DD, YYYY",
-                                          )
-                                        : "--"
-                                }
-                                alwaysEditing={isFieldEditable}
-                                onChange={handleFieldChange}
-                                loading={
-                                    isSavingAll || isFieldLoading("close_date")
-                                }
-                                disabled={!canEdit}
-                            />
-                        </Descriptions.Item>
-
-                        <Descriptions.Item label="Deal Value">
+                        <DetailField label="Deal Value">
                             <EditableField
                                 value={{
                                     amount: currentDeal.value ?? null,
@@ -916,21 +588,356 @@ export default function DealInfoSection({
                                 loading={isSavingAll || isFieldLoading("value")}
                                 disabled={!canEdit}
                             />
-                        </Descriptions.Item>
-
-                        {currentDeal.total_discount != null &&
-                            currentDeal.total_discount > 0 && (
-                                <Descriptions.Item label="Total Discount">
-                                    <Tag color="green" icon={<GiftOutlined />}>
-                                        -
-                                        {Number(
+                            {currentDeal.total_discount != null &&
+                                currentDeal.total_discount > 0 && (
+                                    <Tag
+                                        color="green"
+                                        icon={<GiftOutlined />}
+                                        className="ml-2"
+                                    >
+                                        -{Number(
                                             currentDeal.total_discount,
                                         ).toLocaleString("en-GB")}
                                     </Tag>
-                                </Descriptions.Item>
-                            )}
+                                )}
+                        </DetailField>
 
-                        <Descriptions.Item label="Properties" span={"filled"}>
+                        <DetailField label="Close Date">
+                            <EditableField
+                                value={currentDeal.close_date}
+                                fieldName="close_date"
+                                fieldType="date"
+                                onSave={(value) =>
+                                    handleFieldUpdate("close_date", value)
+                                }
+                                formatValue={(value) =>
+                                    value
+                                        ? dayjs(value.toString()).format(
+                                              "MMM DD, YYYY",
+                                          )
+                                        : "--"
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("close_date")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        <DetailField label="Package(s)">
+                            <EditableField
+                                value={
+                                    currentDeal.packages?.map(
+                                        (p: any) => p.id,
+                                    ) || []
+                                }
+                                fieldName="package_id"
+                                selectorType="packages"
+                                mode="multiple"
+                                displayValue={
+                                    currentDeal.packages?.length
+                                        ? currentDeal.packages
+                                              .map(
+                                                  (pkg: any) =>
+                                                      pkg?.name || pkg,
+                                              )
+                                              .join(", ")
+                                        : "--"
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("package_id", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("package_id")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        <DetailField label="Lead Contact">
+                            <EditableField
+                                value={currentDeal?.lead_id}
+                                fieldName="lead_id"
+                                selectorType="leads"
+                                displayValue={
+                                    currentDeal.contact ? (
+                                        <div className="flex items-center gap-2">
+                                            <Link
+                                                href={route(
+                                                    "lead-contact.show",
+                                                    currentDeal.contact.id,
+                                                )}
+                                                className="text-blue-600 hover:text-blue-800 font-medium"
+                                            >
+                                                {currentDeal.contact
+                                                    .client_name_salutation ||
+                                                    currentDeal.contact
+                                                        .client_name}
+                                            </Link>
+                                            {currentDeal.contact.client_id && (
+                                                <Tag
+                                                    color="blue"
+                                                    className="text-xs"
+                                                >
+                                                    Client
+                                                </Tag>
+                                            )}
+                                        </div>
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("lead_id", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("lead_id")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+                    </DetailSection>
+
+                    {/* Contact Info */}
+                    <DetailSection title="Contact Info">
+                        <DetailField label="Email">
+                            <div className="flex items-center gap-x-2">
+                                {currentDeal.contact?.client_email && (
+                                    <MailOutlined className="text-gray-400 flex-shrink-0" />
+                                )}
+                                {currentDeal.contact?.client_email ? (
+                                    <EditableField
+                                        value={currentDeal.contact.client_email}
+                                        fieldName="email"
+                                        fieldType="email"
+                                        onSave={(value) =>
+                                            handleFieldUpdate("email", value)
+                                        }
+                                        className="text-blue-600 hover:text-blue-800"
+                                        alwaysEditing={isFieldEditable}
+                                        onChange={handleFieldChange}
+                                        loading={
+                                            isSavingAll ||
+                                            isFieldLoading("email")
+                                        }
+                                        disabled={!canEdit}
+                                    />
+                                ) : (
+                                    <span className="text-gray-400">--</span>
+                                )}
+                            </div>
+                        </DetailField>
+
+                        <DetailField label="Mobile">
+                            {currentDeal.contact ? (
+                                <div className="flex items-center gap-x-2">
+                                    <PhoneOutlined className="text-gray-400 flex-shrink-0" />
+                                    <EditableField
+                                        value={getMobileNumber(
+                                            currentDeal.contact.mobile,
+                                        )}
+                                        fieldName="mobile"
+                                        fieldType="phone"
+                                        onSave={(value) =>
+                                            handleFieldUpdate("mobile", value)
+                                        }
+                                        alwaysEditing={isFieldEditable}
+                                        onChange={handleFieldChange}
+                                        loading={
+                                            isSavingAll ||
+                                            isFieldLoading("mobile")
+                                        }
+                                        disabled={!canEdit}
+                                    />
+                                </div>
+                            ) : (
+                                <span className="text-gray-400">--</span>
+                            )}
+                        </DetailField>
+
+                        <DetailField label="Company Name" span={2}>
+                            <EditableField
+                                value={currentDeal.contact?.company_name}
+                                fieldName="company_name"
+                                fieldType="text"
+                                onSave={(value) =>
+                                    handleFieldUpdate("company_name", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll ||
+                                    isFieldLoading("company_name")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+                    </DetailSection>
+
+                    {/* Classification */}
+                    <DetailSection title="Classification">
+                        <DetailField label="Deal Category">
+                            <EditableField
+                                value={currentDeal.category_id}
+                                fieldName="category_id"
+                                selectorType="categories"
+                                displayValue={
+                                    currentDeal.category?.category_name ? (
+                                        <Tag color="blue" className="font-medium">
+                                            {currentDeal.category.category_name}
+                                        </Tag>
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("category_id", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("category_id")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        <DetailField label="Deal Agent">
+                            <EditableField
+                                value={currentDeal.agent_id}
+                                fieldName="agent_id"
+                                selectorType="lead-agents"
+                                displayValue={
+                                    currentDeal.lead_agent?.user ? (
+                                        <UserIndicator
+                                            data={currentDeal.lead_agent.user}
+                                            size="sm"
+                                        />
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("agent_id", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll || isFieldLoading("agent_id")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        {currentDeal?.lead_status && (
+                            <DetailField label="Status">
+                                <Tag
+                                    color={currentDeal.lead_status.label_color}
+                                    className="font-medium"
+                                >
+                                    {currentDeal.lead_status.type}
+                                </Tag>
+                            </DetailField>
+                        )}
+                    </DetailSection>
+
+                    {/* Team */}
+                    <DetailSection title="Team">
+                        <DetailField label="Deal Watchers" span={2}>
+                            <EditableField
+                                value={
+                                    currentDeal.deal_watchers?.map(
+                                        (w: any) => w.id,
+                                    ) || []
+                                }
+                                fieldName="deal_watcher"
+                                selectorType="employees"
+                                mode="multiple"
+                                displayValue={
+                                    currentDeal.deal_watchers &&
+                                    currentDeal.deal_watchers.length > 0 ? (
+                                        <MultiUserIndicator
+                                            users={currentDeal.deal_watchers.map(
+                                                (watcher: any) => ({
+                                                    id: watcher.id,
+                                                    image_url:
+                                                        watcher.image_url ||
+                                                        watcher.image,
+                                                    name: watcher.name,
+                                                }),
+                                            )}
+                                            size="sm"
+                                            maxCount={2}
+                                            showTooltip={true}
+                                        />
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("deal_watcher", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll ||
+                                    isFieldLoading("deal_watcher")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        <DetailField label="Deal Participants" span={2}>
+                            <EditableField
+                                value={
+                                    currentDeal.deal_participants?.map(
+                                        (p: any) => p.id,
+                                    ) || []
+                                }
+                                fieldName="deal_participant"
+                                selectorType="employees"
+                                mode="multiple"
+                                displayValue={
+                                    currentDeal.deal_participants &&
+                                    currentDeal.deal_participants.length > 0 ? (
+                                        <MultiUserIndicator
+                                            users={currentDeal.deal_participants.map(
+                                                (participant: any) => ({
+                                                    id: participant.id,
+                                                    image_url:
+                                                        participant.image_url ||
+                                                        participant.image,
+                                                    name: participant.name,
+                                                }),
+                                            )}
+                                            size="sm"
+                                            maxCount={2}
+                                            showTooltip={true}
+                                        />
+                                    ) : (
+                                        <span className="text-gray-400">--</span>
+                                    )
+                                }
+                                onSave={(value) =>
+                                    handleFieldUpdate("deal_participant", value)
+                                }
+                                alwaysEditing={isFieldEditable}
+                                onChange={handleFieldChange}
+                                loading={
+                                    isSavingAll ||
+                                    isFieldLoading("deal_participant")
+                                }
+                                disabled={!canEdit}
+                            />
+                        </DetailField>
+
+                        <DetailField label="Properties" span={2}>
                             <EditableField
                                 value={
                                     currentDeal.products?.map(
@@ -955,9 +962,7 @@ export default function DealInfoSection({
                                             )}
                                         </div>
                                     ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
+                                        <span className="text-gray-400">--</span>
                                     )
                                 }
                                 onSave={(value) =>
@@ -970,8 +975,8 @@ export default function DealInfoSection({
                                 }
                                 disabled={!canEdit}
                             />
-                        </Descriptions.Item>
-                    </Descriptions>
+                        </DetailField>
+                    </DetailSection>
                 </div>
             ),
         },
@@ -997,7 +1002,7 @@ export default function DealInfoSection({
             key: `category-${category.id}`,
             label: category.name,
             children: (
-                <div className="p-6">
+                <div className="p-4">
                     <CustomFieldDisplay
                         fields={fields}
                         customFieldsData={currentDeal.custom_fields_data || {}}
@@ -1053,12 +1058,14 @@ export default function DealInfoSection({
             <div>
                 {/* Header */}
                 <div
-                    className={`flex items-center justify-between p-6 border-b border-gray-200 ${
-                        isEditMode ? "bg-blue-50" : "bg-white"
+                    className={`flex items-center justify-between px-5 py-3 border-b ${
+                        isEditMode
+                            ? "bg-blue-50 border-blue-100"
+                            : "bg-gray-50/80 border-gray-100"
                     }`}
                 >
                     <div className="flex items-center gap-3">
-                        <h2 className="text-lg font-semibold text-gray-900">
+                        <h2 className="text-sm font-semibold text-gray-700">
                             Deal Information
                         </h2>
                         {isLocked && (

--- a/resources/js/Pages/Deals/Show.tsx
+++ b/resources/js/Pages/Deals/Show.tsx
@@ -1,4 +1,5 @@
 import { Deal } from "@/Types/api/deals";
+import { useState } from "react";
 
 import { Card, Row, Col, Divider, Typography, Alert } from "antd";
 import { RightOutlined, LockOutlined } from "@ant-design/icons";
@@ -68,6 +69,8 @@ export const Show = ({
 
     // ── Page-level refresh ──────────────────────────────────────────
     const { refresh, isRefreshing } = usePageRefresh();
+
+    const [isDealEditMode, setIsDealEditMode] = useState(false);
 
     return (
         <>
@@ -221,6 +224,8 @@ export const Show = ({
                                             taskBoardColumns={taskBoardColumns}
                                             employees={employees}
                                             projects={projects}
+                                            isEditMode={isDealEditMode}
+                                            onEditModeChange={setIsDealEditMode}
                                         />
                                     </Card>
 

--- a/resources/js/Pages/Leads/Components/LeadInfoSection.tsx
+++ b/resources/js/Pages/Leads/Components/LeadInfoSection.tsx
@@ -2,14 +2,10 @@ import { useState, useEffect } from "react";
 import { Lead } from "@/Types/api/leads";
 import { router, usePage } from "@inertiajs/react";
 import {
-    Descriptions,
     Avatar,
     Tabs,
     Button,
-    Dropdown,
-    MenuProps,
     Tag,
-    Divider,
     Space,
     Tooltip,
     message,
@@ -24,7 +20,6 @@ import {
     GlobalOutlined,
     HomeOutlined,
     CalendarOutlined,
-    MoreOutlined,
     CheckSquareOutlined,
     SaveOutlined,
     CloseOutlined,
@@ -35,11 +30,11 @@ import DeleteLead from "@/Features/Leads/DeleteLead";
 import ChangeToClient from "@/Features/Leads/ChangeToClient";
 import SaveTaskModal from "@/Features/Tasks/SaveTask/SaveTaskModal";
 import dayjs from "dayjs";
-import { icons } from "antd/es/image/PreviewGroup";
 import EditableField from "@/Components/EditableField";
 import { useApiMutate } from "@/lib/api/client/useApiMutate";
 import UserIndicator from "@/Components/UserIndicator";
 import axios from "axios";
+import { DetailSection, DetailField } from "@/Components/DetailSection";
 
 interface Props {
     lead: Lead;
@@ -52,6 +47,8 @@ interface Props {
     taskBoardColumns: any[];
     employees: any[];
     projects: any[];
+    isEditMode: boolean;
+    onEditModeChange: (value: boolean) => void;
 }
 
 export default function LeadInfoSection({
@@ -65,6 +62,8 @@ export default function LeadInfoSection({
     taskBoardColumns,
     employees,
     projects,
+    isEditMode,
+    onEditModeChange,
 }: Props) {
     const { props } = usePage();
     const user = props.auth.user;
@@ -79,9 +78,6 @@ export default function LeadInfoSection({
     const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
     const [currentLeadState, setCurrentLeadState] = useState<Lead>(lead);
     const [updatingField, setUpdatingField] = useState<string | null>(null);
-
-    // Edit mode state - when true, all fields become editable
-    const [isEditMode, setIsEditMode] = useState(false);
 
     // Track pending changes in edit mode
     const [pendingChanges, setPendingChanges] = useState<Record<string, any>>(
@@ -142,7 +138,7 @@ export default function LeadInfoSection({
 
     // Toggle edit mode
     const handleToggleEditMode = () => {
-        setIsEditMode(!isEditMode);
+        onEditModeChange(!isEditMode);
         // Clear pending changes when entering edit mode
         if (!isEditMode) {
             setPendingChanges({});
@@ -151,7 +147,7 @@ export default function LeadInfoSection({
 
     // Exit edit mode
     const handleExitEditMode = () => {
-        setIsEditMode(false);
+        onEditModeChange(false);
         setPendingChanges({});
     };
 
@@ -211,7 +207,7 @@ export default function LeadInfoSection({
 
             message.success("All changes saved successfully");
             setPendingChanges({});
-            setIsEditMode(false);
+            onEditModeChange(false);
         } catch (error: any) {
             message.error(error?.message || "Failed to save changes");
         } finally {
@@ -459,47 +455,10 @@ export default function LeadInfoSection({
             key: "overview",
             label: "Overview",
             children: (
-                <div className="p-6">
-                    {/* Header with Avatar and Basic Info */}
-                    {/* <div className="flex items-start gap-x-4 mb-6">
-                        <Avatar
-                            size={80}
-                            src={currentLead?.image_url || lead.image_url}
-                            icon={<UserOutlined />}
-                        />
-                        <div className="flex-1">
-                            <h2 className="text-2xl font-semibold mb-2">
-                                {currentLead?.client_name_salutation ||
-                                    lead.client_name_salutation}
-                            </h2>
-                            <p className="text-gray-600 mb-2">
-                                {currentLead?.client_email || lead.client_email}
-                            </p>
-                            <div className="flex items-center gap-x-4">
-                                {(currentLead?.mobile_with_phonecode ||
-                                    lead.mobile_with_phonecode) !== "--" && (
-                                    <span className="flex items-center">
-                                        <PhoneOutlined className="mr-1" />
-                                        {currentLead?.mobile_with_phonecode ||
-                                            lead.mobile_with_phonecode}
-                                    </span>
-                                )}
-                                {(currentLead?.company_name ||
-                                    lead.company_name) && (
-                                    <span className="text-gray-600">
-                                        {currentLead?.company_name ||
-                                            lead.company_name}
-                                    </span>
-                                )}
-                            </div>
-                        </div>
-                    </div> */}
-
-                    {/* <Divider /> */}
-
-                    <Descriptions column={2} bordered size="middle">
-                        {/* Contact Information */}
-                        <Descriptions.Item label="Name">
+                <div className="p-4 space-y-4">
+                    {/* Contact Information */}
+                    <DetailSection title="Contact Information">
+                        <DetailField label="Name">
                             <EditableField
                                 value={
                                     currentLeadState.client_name_salutation ||
@@ -515,31 +474,15 @@ export default function LeadInfoSection({
                                 loading={isFieldLoading("client_name")}
                                 alwaysEditing={isFieldEditable}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Email">
-                            {currentLeadState.client_email ? (
-                                <div className="flex items-center gap-x-2">
-                                    <MailOutlined className="text-gray-400" />
-                                    <EditableField
-                                        value={currentLeadState.client_email}
-                                        fieldName="client_email"
-                                        fieldType="email"
-                                        onSave={(value) =>
-                                            handleFieldUpdate(
-                                                "client_email",
-                                                value,
-                                            )
-                                        }
-                                        onChange={handleFieldChange}
-                                        className="text-blue-600 hover:text-blue-800"
-                                        alwaysEditing={isFieldEditable}
-                                        loading={isFieldLoading("client_email")}
-                                    />
-                                </div>
-                            ) : (
+                        <DetailField label="Email">
+                            <div className="flex items-center gap-x-2">
+                                {currentLeadState.client_email && (
+                                    <MailOutlined className="text-gray-400 flex-shrink-0" />
+                                )}
                                 <EditableField
-                                    value=""
+                                    value={currentLeadState.client_email || ""}
                                     fieldName="client_email"
                                     fieldType="email"
                                     onSave={(value) =>
@@ -547,15 +490,16 @@ export default function LeadInfoSection({
                                     }
                                     onChange={handleFieldChange}
                                     placeholder="Add email"
+                                    className="text-blue-600 hover:text-blue-800"
                                     alwaysEditing={isFieldEditable}
                                     loading={isFieldLoading("client_email")}
                                 />
-                            )}
-                        </Descriptions.Item>
+                            </div>
+                        </DetailField>
 
-                        <Descriptions.Item label="Mobile">
+                        <DetailField label="Mobile">
                             <div className="flex items-center gap-x-2">
-                                <PhoneOutlined className="text-gray-400" />
+                                <PhoneOutlined className="text-gray-400 flex-shrink-0" />
                                 <EditableField
                                     value={
                                         getMobileNumber(
@@ -575,9 +519,9 @@ export default function LeadInfoSection({
                                     loading={isFieldLoading("mobile")}
                                 />
                             </div>
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Office Phone">
+                        <DetailField label="Office Phone">
                             <EditableField
                                 value={
                                     currentLeadState.office_phone_formatted ||
@@ -594,9 +538,12 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("office")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
+                    </DetailSection>
 
-                        <Descriptions.Item label="Gender">
+                    {/* Personal Details */}
+                    <DetailSection title="Personal Details">
+                        <DetailField label="Gender">
                             <EditableField
                                 value={currentLeadState.gender || ""}
                                 fieldName="gender"
@@ -615,17 +562,15 @@ export default function LeadInfoSection({
                                             {currentLeadState.gender}
                                         </span>
                                     ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
+                                        <span className="text-gray-400">--</span>
                                     )
                                 }
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("gender")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Company">
+                        <DetailField label="Company">
                             <EditableField
                                 value={currentLeadState.company_name || ""}
                                 fieldName="company_name"
@@ -638,19 +583,19 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("company_name")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Website">
-                            {currentLeadState.website ? (
-                                <EditableField
-                                    value={currentLeadState.website}
-                                    fieldName="website"
-                                    fieldType="text"
-                                    onSave={(value) =>
-                                        handleFieldUpdate("website", value)
-                                    }
-                                    onChange={handleFieldChange}
-                                    displayValue={
+                        <DetailField label="Website">
+                            <EditableField
+                                value={currentLeadState.website || ""}
+                                fieldName="website"
+                                fieldType="text"
+                                onSave={(value) =>
+                                    handleFieldUpdate("website", value)
+                                }
+                                onChange={handleFieldChange}
+                                displayValue={
+                                    currentLeadState.website ? (
                                         <a
                                             href={String(
                                                 currentLeadState.website,
@@ -662,28 +607,15 @@ export default function LeadInfoSection({
                                             <GlobalOutlined className="mr-1" />
                                             {currentLeadState.website}
                                         </a>
-                                    }
-                                    alwaysEditing={isFieldEditable}
-                                    loading={isFieldLoading("website")}
-                                />
-                            ) : (
-                                <EditableField
-                                    value=""
-                                    fieldName="website"
-                                    fieldType="text"
-                                    onSave={(value) =>
-                                        handleFieldUpdate("website", value)
-                                    }
-                                    onChange={handleFieldChange}
-                                    placeholder="Add website"
-                                    alwaysEditing={isFieldEditable}
-                                    loading={isFieldLoading("website")}
-                                />
-                            )}
-                        </Descriptions.Item>
+                                    ) : undefined
+                                }
+                                placeholder="Add website"
+                                alwaysEditing={isFieldEditable}
+                                loading={isFieldLoading("website")}
+                            />
+                        </DetailField>
 
-                        {/* Lead Details */}
-                        <Descriptions.Item label="Lead Owner">
+                        <DetailField label="Lead Owner">
                             <EditableField
                                 value={
                                     currentLeadState.lead_owner &&
@@ -707,17 +639,15 @@ export default function LeadInfoSection({
                                             size="sm"
                                         />
                                     ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
+                                        <span className="text-gray-400">--</span>
                                     )
                                 }
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("lead_owner")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Added By">
+                        <DetailField label="Added By">
                             {currentLeadState.added_by ? (
                                 <div className="flex items-center gap-x-2">
                                     <Avatar
@@ -732,11 +662,14 @@ export default function LeadInfoSection({
                                     </span>
                                 </div>
                             ) : (
-                                <span className="text-gray-500">--</span>
+                                <span className="text-gray-400">--</span>
                             )}
-                        </Descriptions.Item>
+                        </DetailField>
+                    </DetailSection>
 
-                        <Descriptions.Item label="Lead Source">
+                    {/* Classification */}
+                    <DetailSection title="Classification">
+                        <DetailField label="Lead Source">
                             <EditableField
                                 value={currentLeadState.source_id || null}
                                 fieldName="source_id"
@@ -758,17 +691,15 @@ export default function LeadInfoSection({
                                                     ?.type}
                                         </Tag>
                                     ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
+                                        <span className="text-gray-400">--</span>
                                     )
                                 }
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("source_id")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Category">
+                        <DetailField label="Category">
                             <EditableField
                                 value={currentLeadState.category_id || null}
                                 fieldName="category_id"
@@ -778,7 +709,8 @@ export default function LeadInfoSection({
                                 }
                                 onChange={handleFieldChange}
                                 displayValue={
-                                    currentLeadState.category?.category_name ? (
+                                    currentLeadState.category
+                                        ?.category_name ? (
                                         <Tag
                                             color="blue"
                                             className="font-medium"
@@ -789,44 +721,44 @@ export default function LeadInfoSection({
                                             }
                                         </Tag>
                                     ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
+                                        <span className="text-gray-400">--</span>
                                     )
                                 }
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("category_id")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Created At">
+                        <DetailField label="Created At">
                             {currentLeadState.created_at ? (
-                                <span>
-                                    <CalendarOutlined className="mr-1" />
+                                <span className="flex items-center gap-1">
+                                    <CalendarOutlined className="text-gray-400" />
                                     {dayjs(currentLeadState.created_at).format(
                                         "MMM DD, YYYY HH:mm",
                                     )}
                                 </span>
                             ) : (
-                                <span className="text-gray-500">--</span>
+                                <span className="text-gray-400">--</span>
                             )}
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Updated At">
+                        <DetailField label="Updated At">
                             {currentLeadState.updated_at ? (
-                                <span>
-                                    <CalendarOutlined className="mr-1" />
+                                <span className="flex items-center gap-1">
+                                    <CalendarOutlined className="text-gray-400" />
                                     {dayjs(currentLeadState.updated_at).format(
                                         "MMM DD, YYYY HH:mm",
                                     )}
                                 </span>
                             ) : (
-                                <span className="text-gray-500">--</span>
+                                <span className="text-gray-400">--</span>
                             )}
-                        </Descriptions.Item>
+                        </DetailField>
+                    </DetailSection>
 
-                        {/* Address Information */}
-                        <Descriptions.Item label="Country">
+                    {/* Address */}
+                    <DetailSection title="Address">
+                        <DetailField label="Country">
                             <EditableField
                                 value={currentLeadState.country || ""}
                                 fieldName="country"
@@ -839,9 +771,9 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("country")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="State">
+                        <DetailField label="State">
                             <EditableField
                                 value={currentLeadState.state || ""}
                                 fieldName="state"
@@ -854,9 +786,9 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("state")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="City">
+                        <DetailField label="City">
                             <EditableField
                                 value={currentLeadState.city || ""}
                                 fieldName="city"
@@ -869,9 +801,9 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("city")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Postal Code">
+                        <DetailField label="Postal Code">
                             <EditableField
                                 value={currentLeadState.postal_code || ""}
                                 fieldName="postal_code"
@@ -884,9 +816,9 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("postal_code")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
 
-                        <Descriptions.Item label="Address" span={2}>
+                        <DetailField label="Address" span={2}>
                             <EditableField
                                 value={currentLeadState.address || ""}
                                 fieldName="address"
@@ -901,20 +833,18 @@ export default function LeadInfoSection({
                                             <HomeOutlined className="mr-1" />
                                             {currentLeadState.address}
                                         </span>
-                                    ) : (
-                                        <span className="text-gray-500">
-                                            --
-                                        </span>
-                                    )
+                                    ) : undefined
                                 }
                                 placeholder="Add address"
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("address")}
                             />
-                        </Descriptions.Item>
+                        </DetailField>
+                    </DetailSection>
 
-                        {/* Notes */}
-                        <Descriptions.Item label="Notes" span={2}>
+                    {/* Notes */}
+                    <DetailSection title="Notes" gridClassName="grid grid-cols-1">
+                        <DetailField label="Notes" span={2}>
                             <EditableField
                                 value={currentLeadState.note || ""}
                                 fieldName="note"
@@ -927,8 +857,8 @@ export default function LeadInfoSection({
                                 alwaysEditing={isFieldEditable}
                                 loading={isFieldLoading("note")}
                             />
-                        </Descriptions.Item>
-                    </Descriptions>
+                        </DetailField>
+                    </DetailSection>
                 </div>
             ),
         },
@@ -937,7 +867,7 @@ export default function LeadInfoSection({
             key: `category-${category.id}`,
             label: category.name,
             children: (
-                <div className="p-6">
+                <div className="p-4">
                     <CustomFieldDisplay
                         fields={fields}
                         customFieldsData={
@@ -999,18 +929,19 @@ export default function LeadInfoSection({
 
             <div>
                 {/* Header */}
-                <div className="flex items-center justify-between p-6 border-b border-gray-200 bg-white">
+                <div className="flex items-center justify-between px-5 py-3 border-b border-gray-100 bg-gray-50/80">
                     <div className="flex items-center gap-x-2">
-                        <h2 className="text-lg font-semibold text-gray-900">
+                        <h2 className="text-sm font-semibold text-gray-700">
                             Lead Information
                         </h2>
-                        {isEditMode && <Tag color="blue">Edit Mode</Tag>}
+                        {isEditMode && (
+                            <Tag color="blue" className="text-xs">
+                                Editing
+                            </Tag>
+                        )}
                         {hasUnsavedChanges && (
-                            <Tag color="orange">
-                                {Object.keys(pendingChanges).length} unsaved{" "}
-                                {Object.keys(pendingChanges).length === 1
-                                    ? "change"
-                                    : "changes"}
+                            <Tag color="orange" className="text-xs">
+                                {Object.keys(pendingChanges).length} unsaved
                             </Tag>
                         )}
                     </div>

--- a/resources/js/Pages/Leads/Show.tsx
+++ b/resources/js/Pages/Leads/Show.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { Lead, LeadCategory } from "@/Types/api/leads";
 import { Deal } from "@/Types/api/deals";
 import { LeadNote } from "@/Types/api/lead-note";
 import DashboardLayout from "@/Components/DashboardLayout";
 import type { PageProps } from "@/Components/DashboardLayout";
 import PageLayout from "@/Components/PageLayout";
-import { Card, Tabs } from "antd";
+import { Card, Tabs, message } from "antd";
 import { User } from "@/Types";
 import LeadInfoSection from "./Components/LeadInfoSection";
 import LeadNotesTab from "./Components/LeadNotesTab";
@@ -59,6 +59,19 @@ const Show = ({
 }: LeadShowProps) => {
     const { props } = usePage<PageProps>();
 
+    const [activeTab, setActiveTab] = useState("profile");
+    const [isEditMode, setIsEditMode] = useState(false);
+
+    const handleTabChange = (key: string) => {
+        if (isEditMode) {
+            message.warning(
+                "Please save or cancel your changes before switching tabs.",
+            );
+            return;
+        }
+        setActiveTab(key);
+    };
+
     const tabItems = [
         {
             key: "profile",
@@ -75,6 +88,8 @@ const Show = ({
                     taskBoardColumns={taskBoardColumns}
                     employees={employees}
                     projects={projects}
+                    isEditMode={isEditMode}
+                    onEditModeChange={setIsEditMode}
                 />
             ),
         },
@@ -160,8 +175,8 @@ const Show = ({
         >
             <div>
                 <Tabs
-                    items={tabItems}
-                    className="lead-tabs"
+                    items={tabItems}                    activeKey={activeTab}
+                    onChange={handleTabChange}                    className="lead-tabs"
                     tabBarStyle={{
                         paddingLeft: 24,
                         paddingRight: 24,


### PR DESCRIPTION
This pull request refactors the display and editing of detail fields throughout the app, replacing Ant Design's `Descriptions` component with new custom `DetailSection` and `DetailField` components. It also introduces a new `FieldRenderer` façade for rendering dynamic custom fields, and improves the editing experience by coordinating edit icons between fields and their values. The changes modernize the UI, improve code clarity, and enable more flexible layouts.

**Component and UI Refactor:**

* Replaced all uses of Ant Design's `Descriptions` and `Descriptions.Item` with new custom `DetailSection` and `DetailField` components, allowing for more flexible layouts and improved styling in `CustomFieldDisplay` and `DealDetailsTab`. (`resources/js/Components/CustomFieldDisplay.tsx`, `resources/js/Pages/Deals/Components/DealDetailsTab.tsx`) [[1]](diffhunk://#diff-c78c643ba85a9b4051088fd4150dceb66a6e89bdc112f6f6da29777d7a48d521L2) [[2]](diffhunk://#diff-c78c643ba85a9b4051088fd4150dceb66a6e89bdc112f6f6da29777d7a48d521R10) [[3]](diffhunk://#diff-c78c643ba85a9b4051088fd4150dceb66a6e89bdc112f6f6da29777d7a48d521L1542-R1542) [[4]](diffhunk://#diff-c78c643ba85a9b4051088fd4150dceb66a6e89bdc112f6f6da29777d7a48d521L1551-R1560) [[5]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL3-R7) [[6]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL58-R61) [[7]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL75-R74) [[8]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL103-R89) [[9]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL116-R104) [[10]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL134-R122) [[11]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL150-R138) [[12]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL168-R156) [[13]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL183-R173) [[14]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL198-R188) [[15]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL211-R203) [[16]](diffhunk://#diff-8e5283f2efc43efd0b90bdf936ae3ccf65666d6dc1936b032bdf5b7a6f04c2ddL223-R215)

* Added new `DetailSection` and `DetailField` components, supporting sectioned, grid-based layouts with optional headings and per-field row spanning. (`resources/js/Components/DetailSection.tsx`)

**Editable Field Coordination:**

* Improved the editing experience by introducing a React context (`DetailFieldEditContext`) that lets child `EditableField` components register their edit handlers with parent `DetailField` components, so the edit icon can appear next to labels on hover and trigger editing. (`resources/js/Components/DetailSection.tsx`, `resources/js/Components/EditableField.tsx`) [[1]](diffhunk://#diff-d64eb40493ce6b480447a90366cc1cfca1ebb966a9d2ab2afc50a4ba7d733d18R1-R101) [[2]](diffhunk://#diff-c8b7e36090d67e7c86715b7ae2a466973eaca19c7fd87419ad97a8706fc6ad56L1-R1) [[3]](diffhunk://#diff-c8b7e36090d67e7c86715b7ae2a466973eaca19c7fd87419ad97a8706fc6ad56R29) [[4]](diffhunk://#diff-c8b7e36090d67e7c86715b7ae2a466973eaca19c7fd87419ad97a8706fc6ad56R267-R284) [[5]](diffhunk://#diff-c8b7e36090d67e7c86715b7ae2a466973eaca19c7fd87419ad97a8706fc6ad56L844-R868)

**Custom Field Rendering Abstraction:**

* Introduced a new `FieldRenderer` component as a strongly-typed façade over `CustomFieldDisplay`, simplifying usage and decoupling detail views from internal custom field logic. (`resources/js/Components/FieldRenderer.tsx`)