### PR TITLE
refactor: improve property interface and lead lifecycle status handling

### DIFF
--- a/resources/js/Features/Leads/Columns/index.tsx
+++ b/resources/js/Features/Leads/Columns/index.tsx
@@ -18,10 +18,13 @@ interface LeadLifecycleStatusOption {
 
 /** Inline-editable lifecycle status cell for the Leads table. */
 function LeadLifecycleStatusCell({ record }: { record: Lead }) {
-    const { props } = usePage<{
-        leadLifecycleStatuses?: LeadLifecycleStatusOption[];
-    }>();
-    const statuses = props.leadLifecycleStatuses ?? [];
+    const { props } = usePage();
+    const statuses =
+        (
+            props as {
+                leadLifecycleStatuses?: LeadLifecycleStatusOption[];
+            }
+        ).leadLifecycleStatuses ?? [];
     const [value, setValue] = useState<number | undefined>(
         record.lead_lifecycle_status_id ?? undefined,
     );

--- a/resources/js/Features/Tasks/SaveTask/SaveTaskModal.tsx
+++ b/resources/js/Features/Tasks/SaveTask/SaveTaskModal.tsx
@@ -92,7 +92,8 @@ interface Lead {
 
 interface Property {
     id: number;
-    title: string;
+    title?: string;
+    name?: string;
 }
 
 interface CreateTaskFormData {
@@ -222,7 +223,9 @@ const SaveTaskModal: React.FC<SaveTaskModalProps> = ({
             return {
                 type: "property" as const,
                 id: anyTask.properties[0].id,
-                name: anyTask.properties[0].title,
+                name:
+                    anyTask.properties[0].title ??
+                    anyTask.properties[0].name,
             };
         }
 
@@ -235,7 +238,12 @@ const SaveTaskModal: React.FC<SaveTaskModalProps> = ({
                     ? deals.find((d) => d.id === relatedEntity.id)?.name
                     : relatedEntity.type === "lead"
                       ? leads.find((l) => l.id === relatedEntity.id)?.client_name
-                      : properties.find((p) => p.id === relatedEntity.id)?.title;
+                      : (() => {
+                            const property = properties.find(
+                                (p) => p.id === relatedEntity.id,
+                            );
+                            return property?.title ?? property?.name;
+                        })();
             return { ...relatedEntity, name: lookupName };
         }
 

--- a/resources/js/Pages/DeveloperProjects/components/ProjectsFiltersModal.tsx
+++ b/resources/js/Pages/DeveloperProjects/components/ProjectsFiltersModal.tsx
@@ -39,7 +39,7 @@ interface FilterLocation {
 
 interface ProjectsFiltersModalProps {
     open: boolean;
-    onClose: (): void;
+    onClose: () => void;
     onApply: (draft: ProjectsFilterDraft) => void;
     onReset: () => void;
     initialValues: ProjectsFilterDraft;

--- a/resources/js/Pages/Leads/Redesign/LeadViewRedesign.tsx
+++ b/resources/js/Pages/Leads/Redesign/LeadViewRedesign.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PageLayout from "@/Components/PageLayout";
 import usePageRefresh from "@/Hooks/usePageRefresh";
 import { router } from "@inertiajs/react";

--- a/resources/js/Pages/Tasks/Index.tsx
+++ b/resources/js/Pages/Tasks/Index.tsx
@@ -126,7 +126,8 @@ interface Lead {
 
 interface Property {
     id: number;
-    name: string;
+    name?: string;
+    title?: string;
 }
 
 export interface TasksIndexProps extends PageProps {

--- a/resources/js/Pages/Tasks/Show.tsx
+++ b/resources/js/Pages/Tasks/Show.tsx
@@ -97,7 +97,8 @@ interface Lead {
 
 interface Property {
     id: number;
-    name: string;
+    name?: string;
+    title?: string;
 }
 
 interface SubTask {


### PR DESCRIPTION
- Made the 'title' property optional in the Property interface across multiple components.
- Updated SaveTaskModal to handle both 'title' and 'name' properties for better task management.
- Enhanced LeadLifecycleStatusCell to ensure proper type handling for lifecycle statuses.