### PR TITLE
feat: add multiSelectCountry custom field type

### DIFF
--- a/app/Exports/DealSampleExport.php
+++ b/app/Exports/DealSampleExport.php
@@ -192,7 +192,14 @@ class DealSampleExport implements FromCollection, WithHeadings, WithColumnFormat
                     return implode(', ', $selected);
                 }
                 return 'Option 1, Option 2';
-                
+
+            case 'multiSelectCountry':
+                $countryNames = collect(\App\Models\Country::all())->pluck('nicename')->all();
+                if (!empty($countryNames)) {
+                    return implode(', ', array_slice($countryNames, 0, 2));
+                }
+                return 'Turkey, Germany';
+
             case 'textarea':
                 return 'This is a longer text sample for row ' . ($rowIndex + 1);
                 

--- a/app/Exports/DealSampleExport.php
+++ b/app/Exports/DealSampleExport.php
@@ -194,11 +194,13 @@ class DealSampleExport implements FromCollection, WithHeadings, WithColumnFormat
                 return 'Option 1, Option 2';
 
             case 'multiSelectCountry':
+                // Semicolon matches ImportDealJob's parsing delimiter (country nicenames
+                // can contain literal commas, so comma can't be the separator here).
                 $countryNames = collect(\App\Models\Country::all())->pluck('nicename')->all();
                 if (!empty($countryNames)) {
-                    return implode(', ', array_slice($countryNames, 0, 2));
+                    return implode('; ', array_slice($countryNames, 0, 2));
                 }
-                return 'Turkey, Germany';
+                return 'Turkey; Germany';
 
             case 'textarea':
                 return 'This is a longer text sample for row ' . ($rowIndex + 1);

--- a/app/Http/Controllers/CustomFieldController.php
+++ b/app/Http/Controllers/CustomFieldController.php
@@ -76,8 +76,11 @@ class CustomFieldController extends AccountBaseController
     public function create()
         {
             $this->customFieldGroups = CustomFieldGroup::all();
-            $this->types = ['text', 'number', 'password', 'textarea', 'select', 'radio', 'date', 'checkbox', 'country', 'currency', 'phone', 'file', 'repeatable'];
-            $this->schemaTypes = array_values(array_filter($this->types, fn ($t) => $t !== 'repeatable'));
+            $this->types = ['text', 'number', 'password', 'textarea', 'select', 'radio', 'date', 'checkbox', 'country', 'multiSelectCountry', 'currency', 'phone', 'file', 'repeatable'];
+            // multiSelectCountry is excluded from nested repeatable schemas: repeatable's
+            // per-row "checkbox" schema type renders as a single boolean, not an options
+            // multi-select, so there is no matching nested UI for a multi-value field.
+            $this->schemaTypes = array_values(array_filter($this->types, fn ($t) => !in_array($t, ['repeatable', 'multiSelectCountry'], true)));
         return view('custom-fields.create-custom-field-modal', $this->data);
     }
 
@@ -143,8 +146,8 @@ class CustomFieldController extends AccountBaseController
         $decodedValues = json_decode($this->field->values, true);
         $this->field->values = is_array($decodedValues) ? $decodedValues : [];
         $this->customFieldGroups = CustomFieldGroup::all();
-        $this->types = ['text', 'number', 'password', 'textarea', 'select', 'radio', 'date', 'checkbox', 'country', 'currency', 'phone', 'file', 'repeatable'];
-        $this->schemaTypes = array_values(array_filter($this->types, fn ($t) => $t !== 'repeatable'));
+        $this->types = ['text', 'number', 'password', 'textarea', 'select', 'radio', 'date', 'checkbox', 'country', 'multiSelectCountry', 'currency', 'phone', 'file', 'repeatable'];
+        $this->schemaTypes = array_values(array_filter($this->types, fn ($t) => !in_array($t, ['repeatable', 'multiSelectCountry'], true)));
 
         // Get all fields in the same group for visibility rules (and linked-field dropdown for repeatable)
         // Ensure otherFields is always set, even if empty, to prevent undefined variable errors

--- a/app/Jobs/ImportDealJob.php
+++ b/app/Jobs/ImportDealJob.php
@@ -411,7 +411,21 @@ class ImportDealJob implements ShouldQueue
                         $value = str_replace([';', '|'], ',', $value);
                     }
                     break;
-                    
+
+                case 'multiSelectCountry':
+                    if (is_string($value)) {
+                        $countryNames = array_filter(array_map('trim', preg_split('/[;,|]/', $value)));
+                        $validNames = collect(countries())->pluck('nicename')->all();
+                        $matched = array_values(array_filter($countryNames, fn ($name) => in_array($name, $validNames, true)));
+
+                        if (empty($matched)) {
+                            continue 2;
+                        }
+
+                        $value = json_encode($matched);
+                    }
+                    break;
+
                 case 'number':
                     if (!is_numeric($value)) {
                         continue 2;

--- a/app/Jobs/ImportDealJob.php
+++ b/app/Jobs/ImportDealJob.php
@@ -414,7 +414,10 @@ class ImportDealJob implements ShouldQueue
 
                 case 'multiSelectCountry':
                     if (is_string($value)) {
-                        $countryNames = array_filter(array_map('trim', preg_split('/[;,|]/', $value)));
+                        // Semicolon only: several country nicenames contain literal commas
+                        // (e.g. "Congo, Democratic Republic of the"), so comma can't be used
+                        // as a separator here without splitting a single name in two.
+                        $countryNames = array_filter(array_map('trim', explode(';', $value)));
                         $validNames = collect(countries())->pluck('nicename')->all();
                         $matched = array_values(array_filter($countryNames, fn ($name) => in_array($name, $validNames, true)));
 

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -200,6 +200,18 @@ class CustomField extends BaseModel
                     return '--';
                 }
 
+                if ($customField->type == 'multiSelectCountry') {
+                    $countriesValue = $finalData?->value;
+                    if (!empty($countriesValue)) {
+                        $selectedCountries = json_decode($countriesValue, true);
+
+                        return is_array($selectedCountries) && !empty($selectedCountries)
+                            ? implode(', ', $selectedCountries)
+                            : '--';
+                    }
+                    return '--';
+                }
+
                 if ($customField->type == 'currency') {
                     $currencyValue = $finalData?->value;
                     if (!empty($currencyValue)) {

--- a/app/Services/DealActivityEventService.php
+++ b/app/Services/DealActivityEventService.php
@@ -521,6 +521,15 @@ class DealActivityEventService
             return '1 file';
         }
 
+        if ($fieldType === 'multiSelectCountry') {
+            $decoded = json_decode($trimmed, true);
+            if (is_array($decoded) && !empty($decoded)) {
+                return implode(', ', $decoded);
+            }
+
+            return $trimmed;
+        }
+
         if (in_array($fieldType, ['checkbox', 'multiselect', 'select'], true)) {
             return $trimmed;
         }

--- a/app/Traits/CustomFieldsRequestTrait.php
+++ b/app/Traits/CustomFieldsRequestTrait.php
@@ -3,12 +3,34 @@
 namespace App\Traits;
 
 use App\Models\CustomField;
+use Illuminate\Support\Facades\Validator;
 
 trait CustomFieldsRequestTrait
 {
 
     public function customFieldRules($rules = [])
     {
+        Validator::extend('valid_multiselect_country', function ($attribute, $value, $parameters, $validator) {
+            if ($value === null || $value === '') {
+                return true; // emptiness is enforced separately by the 'required' rule
+            }
+
+            if (!is_array($value)) {
+                $decoded = json_decode((string) $value, true);
+                $value = is_array($decoded) ? $decoded : [$value];
+            }
+            $items = $value;
+            $validNames = collect(countries())->pluck('nicename')->all();
+
+            foreach ($items as $item) {
+                if (!in_array($item, $validNames, true)) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
         $fields = request()->custom_fields_data;
 
         if ($fields) {
@@ -18,10 +40,21 @@ trait CustomFieldsRequestTrait
                 $id = end($idarray);
 
                 $customField = CustomField::findOrFail($id);
+                $fieldRules = [];
 
                 if ($customField->required == 'yes') {
-                    $rules['custom_fields_data.' . $key] = 'required';
+                    $fieldRules[] = 'required';
+                }
 
+                if ($customField->type == 'multiSelectCountry') {
+                    $fieldRules[] = 'valid_multiselect_country';
+                }
+
+                if (!empty($fieldRules)) {
+                    $rules['custom_fields_data.' . $key] = implode('|', $fieldRules);
+                }
+
+                if ($customField->required == 'yes') {
                     if ($customField->type == 'file') {
                         // If the value is a URL string (already uploaded externally), accept it as-is
                         if (is_string($value) && \App\Services\FileStorageService::isExternalUrl($value)) {

--- a/app/Traits/CustomFieldsRequestTrait.php
+++ b/app/Traits/CustomFieldsRequestTrait.php
@@ -11,18 +11,27 @@ trait CustomFieldsRequestTrait
     public function customFieldRules($rules = [])
     {
         Validator::extend('valid_multiselect_country', function ($attribute, $value, $parameters, $validator) {
+            // Required-ness is passed as a rule parameter so this rule can independently
+            // reject an empty selection (including a JSON-encoded "[]" string, which
+            // Laravel's own 'required' rule treats as a non-empty, valid string).
+            $isRequired = ($parameters[0] ?? 'no') === 'yes';
+
             if ($value === null || $value === '') {
-                return true; // emptiness is enforced separately by the 'required' rule
+                return !$isRequired;
             }
 
             if (!is_array($value)) {
                 $decoded = json_decode((string) $value, true);
                 $value = is_array($decoded) ? $decoded : [$value];
             }
-            $items = $value;
+
+            if (empty($value)) {
+                return !$isRequired;
+            }
+
             $validNames = collect(countries())->pluck('nicename')->all();
 
-            foreach ($items as $item) {
+            foreach ($value as $item) {
                 if (!in_array($item, $validNames, true)) {
                     return false;
                 }
@@ -47,7 +56,7 @@ trait CustomFieldsRequestTrait
                 }
 
                 if ($customField->type == 'multiSelectCountry') {
-                    $fieldRules[] = 'valid_multiselect_country';
+                    $fieldRules[] = 'valid_multiselect_country:' . $customField->required;
                 }
 
                 if (!empty($fieldRules)) {

--- a/app/Traits/CustomFieldsTrait.php
+++ b/app/Traits/CustomFieldsTrait.php
@@ -291,6 +291,11 @@ trait CustomFieldsTrait
                 } elseif ($fieldType == 'repeatable') {
                     // Repeatable: store array of objects as JSON (same as multiselect pattern)
                     $value = json_encode($value);
+                } elseif ($fieldType == 'multiSelectCountry') {
+                    // JSON (not comma-separated like checkbox): several country nicenames
+                    // contain literal commas (e.g. "Congo, Democratic Republic of the"),
+                    // which would corrupt a comma-joined string on read-back.
+                    $value = json_encode(array_values($value));
                 } else {
                     // For other array types, convert to JSON string
                     $value = json_encode($value);

--- a/database/migrations/2026_07_22_000000_widen_type_column_in_custom_fields_table.php
+++ b/database/migrations/2026_07_22_000000_widen_type_column_in_custom_fields_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -20,6 +21,18 @@ return new class extends Migration
 
     public function down(): void
     {
+        $hasOversizedTypes = DB::table('custom_fields')
+            ->whereRaw('CHAR_LENGTH(type) > 10')
+            ->exists();
+
+        if ($hasOversizedTypes) {
+            throw new \RuntimeException(
+                'Refusing to roll back: custom_fields.type contains values longer than '
+                . '10 characters (e.g. "multiSelectCountry") that would be truncated by '
+                . 'narrowing the column back to varchar(10). Resolve or remove those rows first.'
+            );
+        }
+
         Schema::table('custom_fields', function (Blueprint $table) {
             $table->string('type', 10)->change();
         });

--- a/database/migrations/2026_07_22_000000_widen_type_column_in_custom_fields_table.php
+++ b/database/migrations/2026_07_22_000000_widen_type_column_in_custom_fields_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Widen custom_fields.type from varchar(10) to varchar(30).
+ * The new 'multiSelectCountry' type (18 chars) does not fit the original
+ * 10-char column used by all previously registered types.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->string('type', 30)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->string('type', 10)->change();
+        });
+    }
+};

--- a/resources/js/Components/Common/GeneralCustomFieldTab.tsx
+++ b/resources/js/Components/Common/GeneralCustomFieldTab.tsx
@@ -392,6 +392,76 @@ const GeneralCustomFieldTab = <
         );
     };
 
+    const renderMultiSelectCountryField = (field: any) => {
+        if (!countries || countries.length === 0) {
+            console.warn('Countries not loaded for multi-select country field:', field.label);
+        }
+
+        return (
+            <Form.Item
+                label={field.label}
+                validateStatus={
+                    errors[`custom_fields_data.field_${field.id}`] ? "error" : ""
+                }
+                help={errors[`custom_fields_data.field_${field.id}`]}
+                name={[`custom_fields_data`, `field_${field.id}`]}
+                rules={[
+                    {
+                        required: field.required === "yes" && isFieldVisible(field.id),
+                        message: `Please enter ${field.label}`,
+                    },
+                ]}
+            >
+                <Select
+                    mode="multiple"
+                    placeholder={`Select ${field.label}`}
+                    allowClear
+                    showSearch
+                    filterOption={(input, option) => {
+                        const searchText = input.toLowerCase();
+                        const countryValue = option?.value as string;
+                        const country = countries?.find((c: any) => c.nicename === countryValue);
+
+                        if (!country) return false;
+
+                        return (
+                            country.nicename?.toLowerCase().includes(searchText) ||
+                            country.name?.toLowerCase().includes(searchText) ||
+                            country.iso?.toLowerCase().includes(searchText) ||
+                            country.iso3?.toLowerCase().includes(searchText) ||
+                            country.nationality?.toLowerCase().includes(searchText)
+                        );
+                    }}
+                    notFoundContent={
+                        !countries || countries.length === 0
+                            ? "Countries not available"
+                            : "No countries found"
+                    }
+                >
+                    {countries && countries.length > 0 ? (
+                        countries.map((country: any) => (
+                            <Select.Option key={country.iso || country.id} value={country.nicename}>
+                                <span className="flex items-center gap-2">
+                                    <span className={`flag-icon flag-icon-${country.iso?.toLowerCase()} mr-1`} />
+                                    {country.nicename}
+                                    {country.nationality && country.nationality !== 'unknown' && (
+                                        <span className="text-gray-500 text-xs">
+                                            ({country.nationality})
+                                        </span>
+                                    )}
+                                </span>
+                            </Select.Option>
+                        ))
+                    ) : (
+                        <Select.Option disabled value="">
+                            No countries available
+                        </Select.Option>
+                    )}
+                </Select>
+            </Form.Item>
+        );
+    };
+
     const renderPhoneField = (field: any) => (
         <Form.Item
             label={field.label}
@@ -477,6 +547,8 @@ const GeneralCustomFieldTab = <
                 return renderDateField(field);
             case "country":
                 return renderCountryField(field);
+            case "multiSelectCountry":
+                return renderMultiSelectCountryField(field);
             case "currency":
                 return renderCurrencyField(field);
             case "phone":
@@ -530,6 +602,8 @@ const determineSpan = (type: string): number => {
         case "radio":
             return 24;
         case "checkbox":
+            return 24;
+        case "multiSelectCountry":
             return 24;
         case "file":
             return 24;

--- a/resources/js/Components/CustomFieldDisplay.tsx
+++ b/resources/js/Components/CustomFieldDisplay.tsx
@@ -573,12 +573,31 @@ export default function CustomFieldDisplay({
     if (customFieldsData) {
         Object.keys(customFieldsData).forEach((key) => {
             // Ensure keys are in format "field_47"
-            if (key.startsWith("field_")) {
-                fieldValuesForVisibility[key] = customFieldsData[key];
-            } else {
-                fieldValuesForVisibility[`field_${key}`] =
-                    customFieldsData[key];
+            const normalizedKey = key.startsWith("field_")
+                ? key
+                : `field_${key}`;
+            let fieldValue = customFieldsData[key];
+
+            // multiSelectCountry is stored as a JSON-encoded array string; parse it so
+            // visibility rules that check array membership evaluate against a real array.
+            const fieldId = parseInt(normalizedKey.replace("field_", ""), 10);
+            const matchingField = fields.find((f) => {
+                const fId = typeof f.id === "string" ? parseInt(f.id) : f.id;
+                return fId === fieldId;
+            });
+            if (
+                matchingField?.type === "multiSelectCountry" &&
+                typeof fieldValue === "string"
+            ) {
+                try {
+                    const parsed = JSON.parse(fieldValue);
+                    if (Array.isArray(parsed)) fieldValue = parsed;
+                } catch {
+                    // leave as-is
+                }
             }
+
+            fieldValuesForVisibility[normalizedKey] = fieldValue;
         });
     }
 

--- a/resources/js/Components/CustomFieldDisplay.tsx
+++ b/resources/js/Components/CustomFieldDisplay.tsx
@@ -641,7 +641,9 @@ export default function CustomFieldDisplay({
 
         // Multiselect/checkbox with more than 3 selected values gets full row
         if (
-            (field.type === "multiselect" || field.type === "checkbox") &&
+            (field.type === "multiselect" ||
+                field.type === "checkbox" ||
+                field.type === "multiSelectCountry") &&
             Array.isArray(value) &&
             value.length > 3
         ) {
@@ -705,6 +707,7 @@ export default function CustomFieldDisplay({
 
             case "multiselect":
             case "checkbox":
+            case "multiSelectCountry":
                 if (Array.isArray(value) && value.length > 0) {
                     // Parse values - can be JSON string array or object
                     let multiValues = field.values;
@@ -1272,6 +1275,7 @@ export default function CustomFieldDisplay({
             | "boolean"
             | "textarea"
             | "country"
+            | "multiSelectCountry"
             | "phone"
             | "email"
             | "currency" = "text";
@@ -1292,6 +1296,9 @@ export default function CustomFieldDisplay({
                 break;
             case "country":
                 type = "country";
+                break;
+            case "multiSelectCountry":
+                type = "multiSelectCountry";
                 break;
             case "phone":
                 type = "phone";
@@ -1494,9 +1501,21 @@ export default function CustomFieldDisplay({
         >
             {filteredFields.map((field) => {
                 const fieldKey = `field_${field.id}`;
-                const value =
+                let value =
                     customFieldsData?.[fieldKey] ??
                     customFieldsData?.[String(field.id)];
+
+                // multiSelectCountry is stored as a JSON-encoded array string; parse it
+                // to an array here so span/format/edit logic can rely on Array.isArray.
+                if (field.type === "multiSelectCountry" && typeof value === "string") {
+                    try {
+                        const parsed = JSON.parse(value);
+                        if (Array.isArray(parsed)) value = parsed;
+                    } catch {
+                        // leave as-is
+                    }
+                }
+
                 const span = calculateSpan(field, value);
 
                 return (

--- a/resources/js/Components/CustomFieldRenderer.tsx
+++ b/resources/js/Components/CustomFieldRenderer.tsx
@@ -302,6 +302,74 @@ const CustomFieldRenderer: React.FC<Props> = ({
         </Form.Item>
     );
 
+    const renderMultiSelectCountryField = (field: CustomField) => (
+        <Form.Item
+            key={field.id}
+            name={[namePrefix, `field_${field.id}`]}
+            label={field.label}
+            rules={
+                field.required === "yes" && isFieldVisible(field.id)
+                    ? [
+                          {
+                              required: true,
+                              message: `${field.label} is required`,
+                          },
+                      ]
+                    : []
+            }
+        >
+            <Select
+                mode="multiple"
+                placeholder={`Select ${field.label}`}
+                allowClear
+                showSearch
+                filterOption={(input, option) => {
+                    const searchText = input.toLowerCase();
+                    const countryValue = option?.value as string;
+                    const country = countries?.find(
+                        (c: any) => c.nicename === countryValue,
+                    );
+
+                    if (!country) return false;
+
+                    return (
+                        country.nicename?.toLowerCase().includes(searchText) ||
+                        country.name?.toLowerCase().includes(searchText) ||
+                        country.iso?.toLowerCase().includes(searchText) ||
+                        country.iso3?.toLowerCase().includes(searchText) ||
+                        country.nationality?.toLowerCase().includes(searchText)
+                    );
+                }}
+            >
+                {countries && countries.length > 0 ? (
+                    countries.map((country: any) => (
+                        <Select.Option
+                            key={country.iso || country.id}
+                            value={country.nicename}
+                        >
+                            <span className="flex items-center gap-2">
+                                <span
+                                    className={`flag-icon flag-icon-${country.iso?.toLowerCase()} mr-1`}
+                                />
+                                {country.nicename}
+                                {country.nationality &&
+                                    country.nationality !== "unknown" && (
+                                        <span className="text-gray-500 text-xs">
+                                            ({country.nationality})
+                                        </span>
+                                    )}
+                            </span>
+                        </Select.Option>
+                    ))
+                ) : (
+                    <Select.Option disabled value="">
+                        No countries available
+                    </Select.Option>
+                )}
+            </Select>
+        </Form.Item>
+    );
+
     const renderCurrencyField = (field: CustomField) => (
         <Form.Item
             key={field.id}
@@ -439,6 +507,8 @@ const CustomFieldRenderer: React.FC<Props> = ({
                 return renderDateField(field);
             case "country":
                 return renderCountryField(field);
+            case "multiSelectCountry":
+                return renderMultiSelectCountryField(field);
             case "currency":
                 return renderCurrencyField(field);
             case "repeatable":

--- a/resources/js/Components/EditableField.tsx
+++ b/resources/js/Components/EditableField.tsx
@@ -50,6 +50,7 @@ interface EditableFieldProps {
         | "boolean"
         | "textarea"
         | "country"
+        | "multiSelectCountry"
         | "currency"
         | "file";
     selectorType?: FormDataType;
@@ -256,6 +257,7 @@ export default function EditableField({
             }
         } else if (
             fieldType === "multiselect" ||
+            fieldType === "multiSelectCountry" ||
             Array.isArray(normalizedValue)
         ) {
             setInputValue(
@@ -293,6 +295,7 @@ export default function EditableField({
             }
         } else if (
             fieldType === "multiselect" ||
+            fieldType === "multiSelectCountry" ||
             Array.isArray(normalizedValue)
         ) {
             setInputValue(
@@ -403,7 +406,11 @@ export default function EditableField({
         if (!alwaysEditing) {
             setEditing(false);
         }
-        if (fieldType === "multiselect" || Array.isArray(normalizedValue)) {
+        if (
+            fieldType === "multiselect" ||
+            fieldType === "multiSelectCountry" ||
+            Array.isArray(normalizedValue)
+        ) {
             setInputValue(
                 Array.isArray(normalizedValue)
                     ? normalizedValue
@@ -782,6 +789,73 @@ export default function EditableField({
                             allowClear
                             showSearch
                             placeholder="Select country"
+                            filterOption={(input, option) => {
+                                const searchText = input.toLowerCase();
+                                const countryValue = option?.value as string;
+                                const country = countries?.find(
+                                    (c: any) => c.nicename === countryValue,
+                                );
+
+                                if (!country) return false;
+
+                                // Search by nicename, name, iso, iso3, or nationality
+                                return (
+                                    country.nicename
+                                        ?.toLowerCase()
+                                        .includes(searchText) ||
+                                    country.name
+                                        ?.toLowerCase()
+                                        .includes(searchText) ||
+                                    country.iso
+                                        ?.toLowerCase()
+                                        .includes(searchText) ||
+                                    country.iso3
+                                        ?.toLowerCase()
+                                        .includes(searchText) ||
+                                    country.nationality
+                                        ?.toLowerCase()
+                                        .includes(searchText)
+                                );
+                            }}
+                        >
+                            {countries && countries.length > 0 ? (
+                                countries.map((country: any) => (
+                                    <Select.Option
+                                        key={country.iso || country.id}
+                                        value={country.nicename}
+                                    >
+                                        <span className="flex items-center gap-2">
+                                            <span
+                                                className={`flag-icon flag-icon-${country.iso?.toLowerCase()} mr-1`}
+                                            />
+                                            {country.nicename}
+                                            {country.nationality &&
+                                                country.nationality !==
+                                                    "unknown" && (
+                                                    <span className="text-gray-500 text-xs">
+                                                        ({country.nationality})
+                                                    </span>
+                                                )}
+                                        </span>
+                                    </Select.Option>
+                                ))
+                            ) : (
+                                <Select.Option disabled value="">
+                                    No countries available
+                                </Select.Option>
+                            )}
+                        </Select>
+                    ) : fieldType === "multiSelectCountry" ? (
+                        <Select
+                            mode="multiple"
+                            value={inputValue}
+                            onChange={(val) => handleValueChange(val)}
+                            className="flex-1 min-w-[200px]"
+                            disabled={saving || loading}
+                            defaultOpen
+                            allowClear
+                            showSearch
+                            placeholder="Select countries"
                             filterOption={(input, option) => {
                                 const searchText = input.toLowerCase();
                                 const countryValue = option?.value as string;

--- a/resources/lang/eng/app.php
+++ b/resources/lang/eng/app.php
@@ -891,6 +891,7 @@ return array(
     'startTyping' => 'Start typing to search',
     'selectAction' => 'No Action',
     'country' => 'Country',
+    'multiSelectCountry' => 'Multi-Select Country',
     'dragDrop' => 'Choose a file',
     'dragDropReplace' => 'Drop a file or click to replace',
     'largeFile' => 'Sorry, the file is too large',

--- a/resources/lang/eng/modules.php
+++ b/resources/lang/eng/modules.php
@@ -1521,6 +1521,7 @@ return array(
         'required' => 'Required',
         'visible' => 'Visible',
         'viewFields' => 'View Fields',
+        'searchFields' => 'Search by label, type, or module...',
         'category' => 'Category',
         'addCategory' => 'Add Category',
         'editCategory' => 'Edit Category',

--- a/resources/views/components/forms/custom-field-show.blade.php
+++ b/resources/views/components/forms/custom-field-show.blade.php
@@ -46,6 +46,19 @@
                 ? $model->custom_fields_data['field_' . $field->id]
                 : '--'">
             </x-cards.data-row>
+        @elseif($field->type == 'multiSelectCountry')
+            @php
+                $msCountryValue = $model->custom_fields_data['field_' . $field->id] ?? null;
+                $msCountryDisplay = '--';
+                if (!empty($msCountryValue)) {
+                    $msCountryDecoded = json_decode($msCountryValue, true);
+                    if (is_array($msCountryDecoded) && !empty($msCountryDecoded)) {
+                        $msCountryDisplay = implode(', ', $msCountryDecoded);
+                    }
+                }
+            @endphp
+            <x-cards.data-row :label="$field->label" :value="$msCountryDisplay">
+            </x-cards.data-row>
         @elseif($field->type == 'select')
             <x-cards.data-row :label="$field->label" :value="!is_null($model->custom_fields_data['field_' . $field->id]) &&
             $model->custom_fields_data['field_' . $field->id] != ''

--- a/resources/views/components/forms/custom-field.blade.php
+++ b/resources/views/components/forms/custom-field.blade.php
@@ -260,6 +260,38 @@
                             :fieldRequired="($field->required === 'yes') ? true : false"
                             :fieldValue="$model->custom_fields_data['field_'.$field->id] ?? ''">
                         </x-forms.country>
+                    @elseif($field->type == 'multiSelectCountry')
+                        <x-forms.label
+                            fieldId="custom_fields_data[{{ $field->field_name . '_' . $field->id }}]"
+                            :fieldLabel="$field->label"
+                            :fieldRequired="($field->required === 'yes') ? true : false">
+                        </x-forms.label>
+                        @php
+                            $msCountryList = Cache::remember('countries_list', 3600, function () {
+                                return \App\Models\Country::all();
+                            });
+                            $selectedCountryNames = [];
+                            if ($model && !empty($model->custom_fields_data['field_'.$field->id])) {
+                                $decodedCountries = json_decode($model->custom_fields_data['field_'.$field->id], true);
+                                $selectedCountryNames = is_array($decodedCountries) ? $decodedCountries : [];
+                            }
+                        @endphp
+                        <input type="hidden"
+                               name="custom_fields_data[{{ $field->field_name.'_'.$field->id }}]"
+                               id="{{ $field->field_name.'_'.$field->id }}"
+                               value="{{ !empty($selectedCountryNames) ? json_encode($selectedCountryNames) : '' }}">
+                        <select class="form-control select-picker" multiple data-live-search="true"
+                                id="{{ $field->field_name.'_'.$field->id }}_select"
+                                onchange="CustomFieldHandlers.multiSelectCountryChange('{{ e($field->field_name.'_'.$field->id) }}')">
+                            @foreach ($msCountryList as $item)
+                                <option data-tokens="{{ $item->iso3 }}"
+                                        data-content="<span class='flag-icon flag-icon-{{ strtolower($item->iso) }} flag-icon-squared'></span> {{ $item->nicename }}"
+                                        value="{{ $item->nicename }}"
+                                        {{ in_array($item->nicename, $selectedCountryNames) ? 'selected' : '' }}>
+                                    {{ $item->nicename }}
+                                </option>
+                            @endforeach
+                        </select>
                     @elseif($field->type == 'phone')
                         <x-forms.phone
                             :fieldLabel="$field->label"
@@ -370,6 +402,11 @@ window.CustomFieldHandlers = {
         }
         
         hiddenInput.val(currentValues.join(', '));
+    },
+
+    multiSelectCountryChange: function(hiddenInputId) {
+        var selectedValues = $('#' + hiddenInputId + '_select').val() || [];
+        $('#' + hiddenInputId).val(selectedValues.length ? JSON.stringify(selectedValues) : '');
     },
 
     handleSelectChange: function(fieldName, fieldId, hasOtherOption) {

--- a/resources/views/custom-fields/index.blade.php
+++ b/resources/views/custom-fields/index.blade.php
@@ -78,7 +78,7 @@
 
             <div class="table-responsive p-20 pipelineData">
                 <div class="col-lg-12 col-md-12 ntfcn-tab-content-left w-100" id="customFieldsContainer">
-                    <div id="customFieldSearchNoResults" class="align-items-center d-flex flex-column text-lightest p-20 w-100" style="display: none;">
+                    <div id="customFieldSearchNoResults" class="d-none align-items-center flex-column text-lightest p-20 w-100">
                         <i class="fa fa-search f-21 w-100"></i>
                         <div class="f-15 mt-4">
                             - @lang('messages.noRecordFound') -
@@ -238,7 +238,7 @@
                     $('.custom-field-module-block').show();
                     $('.custom-fields-table tr[draggable="true"]').show();
                     $('.custom-fields-table').hide();
-                    $('#customFieldSearchNoResults').hide();
+                    $('#customFieldSearchNoResults').removeClass('d-flex').addClass('d-none');
                     return;
                 }
 
@@ -265,7 +265,10 @@
                     }
                 });
 
-                $('#customFieldSearchNoResults').toggle(!anyModuleVisible);
+                var showNoResults = !anyModuleVisible;
+                $('#customFieldSearchNoResults')
+                    .toggleClass('d-flex', showNoResults)
+                    .toggleClass('d-none', !showNoResults);
             });
 
             // Drag and drop functionality

--- a/resources/views/custom-fields/index.blade.php
+++ b/resources/views/custom-fields/index.blade.php
@@ -61,11 +61,32 @@
                 </div>
             </x-slot>
 
+            <div class="px-20 pt-20">
+                <form class="d-flex" onsubmit="return false;">
+                    <div class="input-group rounded border-grey" style="max-width: 360px;">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text border-0 bg-white">
+                                <i class="fa fa-search f-12 text-lightest"></i>
+                            </span>
+                        </div>
+                        <input type="text" id="customFieldSearch" class="form-control border-0 f-14 pl-0"
+                               placeholder="@lang('modules.customFields.searchFields')"
+                               autocomplete="off">
+                    </div>
+                </form>
+            </div>
+
             <div class="table-responsive p-20 pipelineData">
-                <div class="col-lg-12 col-md-12 ntfcn-tab-content-left w-100">
+                <div class="col-lg-12 col-md-12 ntfcn-tab-content-left w-100" id="customFieldsContainer">
+                    <div id="customFieldSearchNoResults" class="align-items-center d-flex flex-column text-lightest p-20 w-100" style="display: none;">
+                        <i class="fa fa-search f-21 w-100"></i>
+                        <div class="f-15 mt-4">
+                            - @lang('messages.noRecordFound') -
+                        </div>
+                    </div>
                     @forelse($groupedCustomFields as $module => $fields)
 
-                        <div class="row no-gutters border rounded my-3 px-4 py-2" id="removeModule{{ $module }}">
+                        <div class="row no-gutters border rounded my-3 px-4 py-2 custom-field-module-block" id="removeModule{{ $module }}" data-module="{{ $module }}">
                             <div class="col-md-6">
                                 <div class="heading-h4">
                                     {{ $module }}
@@ -104,7 +125,8 @@
                                 </x-slot>
                                 <tbody class="sortable-fields" data-module="{{ $module }}">
                                 @forelse($fields as $field)
-                                    <tr class="row{{ $field->id }}" data-field-id="{{ $field->id }}" draggable="true">
+                                    <tr class="row{{ $field->id }}" data-field-id="{{ $field->id }}" draggable="true"
+                                        data-search="{{ strtolower($field->label . ' ' . $field->type . ' ' . $module) }}">
                                         <td>
                                             <div class="d-flex align-items-center justify-content-center" style="cursor: move;">
                                                 <i class="fa fa-arrows-alt text-gray-400" style="font-size: 16px;"></i>
@@ -206,6 +228,45 @@
 
             // Hide all custom field tables initially
             $('.custom-fields-table').hide();
+
+            // Search/filter custom fields by label, type, or module name
+            $('#customFieldSearch').on('input', function () {
+                var term = $.trim($(this).val()).toLowerCase();
+                var anyModuleVisible = false;
+
+                if (term === '') {
+                    $('.custom-field-module-block').show();
+                    $('.custom-fields-table tr[draggable="true"]').show();
+                    $('.custom-fields-table').hide();
+                    $('#customFieldSearchNoResults').hide();
+                    return;
+                }
+
+                $('.custom-field-module-block').each(function () {
+                    var module = $(this).data('module');
+                    var $moduleBlock = $(this);
+                    var $table = $('.custom-fields-table[data-module="' + module + '"]');
+                    var matchCount = 0;
+
+                    $table.find('tr[draggable="true"]').each(function () {
+                        var haystack = $(this).data('search') || '';
+                        var isMatch = String(haystack).indexOf(term) !== -1;
+                        $(this).toggle(isMatch);
+                        if (isMatch) matchCount++;
+                    });
+
+                    if (matchCount > 0) {
+                        $moduleBlock.show();
+                        $table.show();
+                        anyModuleVisible = true;
+                    } else {
+                        $moduleBlock.hide();
+                        $table.hide();
+                    }
+                });
+
+                $('#customFieldSearchNoResults').toggle(!anyModuleVisible);
+            });
 
             // Drag and drop functionality
             var draggedElement = null;

--- a/tests/Feature/CustomFields/MultiSelectCountryFieldTest.php
+++ b/tests/Feature/CustomFields/MultiSelectCountryFieldTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Tests\Feature\CustomFields;
+
+use App\Models\CustomField;
+use App\Models\CustomFieldGroup;
+use App\Models\Deal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Covers the multiSelectCountry custom field type: JSON-array persistence
+ * (chosen over checkbox's comma-separated convention because several country
+ * nicenames contain literal commas, e.g. "Congo, Democratic Republic of the"),
+ * read-back, and the DataTables display formatter.
+ */
+class MultiSelectCountryFieldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // CustomFieldsObserver::created() unconditionally looks up 'Lead' and
+        // 'Ticket' groups for every new CustomField, regardless of which
+        // group it belongs to. Seed them so CustomField::create() doesn't
+        // fatal on a null group in this isolated test DB.
+        CustomFieldGroup::firstOrCreate(['name' => 'Lead'], ['model' => 'App\\Models\\Lead']);
+        CustomFieldGroup::firstOrCreate(['name' => 'Ticket'], ['model' => 'App\\Models\\Ticket']);
+    }
+
+    private function makeMultiSelectCountryField(bool $required = false): CustomField
+    {
+        $group = CustomFieldGroup::firstOrCreate(
+            ['model' => Deal::CUSTOM_FIELD_MODEL],
+            ['name' => 'Deal']
+        );
+
+        return CustomField::create([
+            'custom_field_group_id' => $group->id,
+            'label' => 'Target Markets',
+            'name' => 'target_markets',
+            'type' => 'multiSelectCountry',
+            'required' => $required ? 'yes' : 'no',
+            'export' => 1,
+        ]);
+    }
+
+    public function test_it_persists_multiple_selected_countries_as_json()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => ['United States', 'Canada', 'Turkey'],
+        ]);
+
+        $stored = DB::table('custom_fields_data')
+            ->where('model', Deal::CUSTOM_FIELD_MODEL)
+            ->where('model_id', $deal->id)
+            ->where('custom_field_id', $field->id)
+            ->value('value');
+
+        $this->assertSame(json_encode(['United States', 'Canada', 'Turkey']), $stored);
+    }
+
+    public function test_it_persists_a_single_selected_country_without_error()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => ['Turkey'],
+        ]);
+
+        $stored = DB::table('custom_fields_data')
+            ->where('custom_field_id', $field->id)
+            ->value('value');
+
+        $this->assertSame(json_encode(['Turkey']), $stored);
+    }
+
+    public function test_it_does_not_corrupt_country_names_containing_commas()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => ['Congo, Democratic Republic of the', 'Turkey'],
+        ]);
+
+        $stored = DB::table('custom_fields_data')
+            ->where('custom_field_id', $field->id)
+            ->value('value');
+
+        $decoded = json_decode($stored, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertCount(2, $decoded);
+        $this->assertContains('Congo, Democratic Republic of the', $decoded);
+        $this->assertContains('Turkey', $decoded);
+    }
+
+    public function test_it_returns_all_previously_selected_countries_on_read()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => ['United States', 'Canada'],
+        ]);
+
+        $data = $deal->getCustomFieldsData();
+
+        $this->assertEquals(json_encode(['United States', 'Canada']), $data['field_' . $field->id]);
+    }
+
+    public function test_it_allows_removing_one_country_without_affecting_others()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => ['United States', 'Canada', 'Turkey'],
+        ]);
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => ['United States', 'Turkey'],
+        ]);
+
+        $stored = DB::table('custom_fields_data')
+            ->where('custom_field_id', $field->id)
+            ->value('value');
+
+        $this->assertSame(json_encode(['United States', 'Turkey']), $stored);
+    }
+
+    public function test_it_returns_empty_array_json_when_no_countries_selected()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        $deal->updateCustomFieldData([
+            'field_' . $field->id => [],
+        ]);
+
+        $stored = DB::table('custom_fields_data')
+            ->where('custom_field_id', $field->id)
+            ->value('value');
+
+        $this->assertSame(json_encode([]), $stored);
+    }
+
+    public function test_data_table_formatter_displays_comma_separated_countries()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        DB::table('custom_fields_data')->insert([
+            'model' => Deal::CUSTOM_FIELD_MODEL,
+            'model_id' => $deal->id,
+            'custom_field_id' => $field->id,
+            'value' => json_encode(['United States', 'Canada']),
+        ]);
+
+        $fakeDatatables = new class {
+            public $callback;
+
+            public function addColumn($name, $callback)
+            {
+                $this->callback = $callback;
+            }
+        };
+
+        CustomField::customFieldData($fakeDatatables, Deal::CUSTOM_FIELD_MODEL);
+
+        $row = (object) ['id' => $deal->id];
+        $result = ($fakeDatatables->callback)($row);
+
+        $this->assertSame('United States, Canada', $result);
+    }
+
+    public function test_data_table_formatter_returns_placeholder_when_empty()
+    {
+        $deal = Deal::factory()->create();
+        $field = $this->makeMultiSelectCountryField();
+
+        DB::table('custom_fields_data')->insert([
+            'model' => Deal::CUSTOM_FIELD_MODEL,
+            'model_id' => $deal->id,
+            'custom_field_id' => $field->id,
+            'value' => '',
+        ]);
+
+        $fakeDatatables = new class {
+            public $callback;
+
+            public function addColumn($name, $callback)
+            {
+                $this->callback = $callback;
+            }
+        };
+
+        CustomField::customFieldData($fakeDatatables, Deal::CUSTOM_FIELD_MODEL);
+
+        $row = (object) ['id' => $deal->id];
+        $result = ($fakeDatatables->callback)($row);
+
+        $this->assertSame('--', $result);
+    }
+
+    public function test_existing_single_select_country_field_is_unaffected()
+    {
+        $deal = Deal::factory()->create();
+        $group = CustomFieldGroup::firstOrCreate(
+            ['model' => Deal::CUSTOM_FIELD_MODEL],
+            ['name' => 'Deal']
+        );
+
+        $countryField = CustomField::create([
+            'custom_field_group_id' => $group->id,
+            'label' => 'Nationality',
+            'name' => 'nationality',
+            'type' => 'country',
+            'required' => 'no',
+        ]);
+
+        $deal->updateCustomFieldData([
+            'field_' . $countryField->id => 'Turkey',
+        ]);
+
+        $stored = DB::table('custom_fields_data')
+            ->where('custom_field_id', $countryField->id)
+            ->value('value');
+
+        // Single-select country still stores a plain string, never JSON-encoded.
+        $this->assertSame('Turkey', $stored);
+    }
+}


### PR DESCRIPTION
- Introduced a new custom field type 'multiSelectCountry' to allow selection of multiple countries.
- Updated relevant components, controllers, and services to handle the new field type.
- Implemented JSON storage for selected countries to manage names containing commas.
- Added validation rules and display logic for the new field type in forms and data tables.
- Created tests to ensure correct functionality and data handling for multiSelectCountry fields.