### PR TITLE
feat: refactor deal workspace to fetch notes, tasks, meetings, and fi…

### DIFF
--- a/app/Http/Controllers/DealController.php
+++ b/app/Http/Controllers/DealController.php
@@ -684,60 +684,16 @@ class DealController extends AccountBaseController
             'restrictPackageOrProperty' => (bool) (\App\Models\LeadSetting::first()->restrict_package_or_property ?? false),
 
             // ---- C1 deferred (queries run only when Inertia resolves these) ----
-            'notes' => Inertia::defer(function () use ($dealId) {
-                $notes = DealNote::with('addedBy')
-                    ->where('deal_id', $dealId)
-                    ->orderBy('created_at', 'desc')
-                    ->get();
-
-                $viewNotesPermission = user()->permission('view_deal_note');
-
-                if ($viewNotesPermission == 'none') {
-                    return collect();
-                }
-                if ($viewNotesPermission == 'added') {
-                    return $notes->where('added_by', user()->id)->values();
-                }
-                if ($viewNotesPermission == 'owned') {
-                    return $notes->where('added_by', '!=', user()->id)->values();
-                }
-
-                return $notes;
-            }),
-            'dealFollowUps' => Inertia::defer(function () use ($dealId) {
-                $dealFollowUps = DealFollowUp::with(['addedBy:id,name,image', 'meetingType', 'meetingSummary'])
-                    ->where('deal_id', $dealId)
-                    ->orderBy('next_follow_up_date', 'desc')
-                    ->get();
-
-                $allParticipantIds = $dealFollowUps->flatMap(fn ($f) => $f->participants ?? [])->unique()->values();
-                $participantUsersMap = $allParticipantIds->isEmpty()
-                    ? collect()
-                    : User::whereIn('id', $allParticipantIds)->get(['id', 'name', 'image'])->keyBy('id');
-
-                $dealFollowUps->each(function ($f) use ($participantUsersMap) {
-                    $f->participant_users = collect($f->participants ?? [])
-                        ->map(fn ($pid) => $participantUsersMap->get($pid))
-                        ->filter()
-                        ->map(fn ($u) => [
-                            'id' => $u->id,
-                            'name' => $u->name,
-                            'image' => $u->image ? $u->image_url : null,
-                        ])
-                        ->values()
-                        ->toArray();
-                });
-
-                return $dealFollowUps;
-            }),
-            'files' => Inertia::defer(function () use ($deal) {
-                $files = $deal->files()->orderBy('created_at', 'desc')->get();
-                if (user()->permission('view_lead_files') == 'added') {
-                    return $files->where('added_by', user()->id)->values();
-                }
-
-                return $files;
-            }),
+            // notes / dealFollowUps / files / tasks are no longer deferred props —
+            // they were all bundled into Inertia's single default group, so one
+            // slow/broken closure among the 17 here could stall every one of them
+            // at once (notes, tasks, meetings and files tabs all stuck loading
+            // together). Each now fetches independently via its own JSON endpoint
+            // (deals.notes.index / deals.tasks.index / deals.meetings.index /
+            // deals.files.index) the same way offers/recommendations already do —
+            // one tab's slow request can no longer block the others.
+            // The rest are still deferred, but split into explicit groups so a
+            // slow query in one group no longer blocks the others either.
             'proposals' => Inertia::defer(function () use ($dealId) {
                 if (!in_array(user()->permission('view_lead_proposals'), ['all', 'added'])) {
                     return collect();
@@ -757,31 +713,29 @@ class DealController extends AccountBaseController
                 }
 
                 return $proposals;
-            }),
+            }, 'timeline'),
             'histories' => Inertia::defer(fn () => DealHistory::where('deal_id', $dealId)
                 ->orderBy('created_at', 'desc')
-                ->get()),
+                ->limit(200)
+                ->get(), 'timeline'),
             'activities' => Inertia::defer(fn () => CommunicationActivity::where('deal_id', $dealId)
                 ->with(['deal', 'lead'])
                 ->orderBy('timestamp', 'desc')
-                ->get()),
+                ->limit(200)
+                ->get(), 'timeline'),
             'consents' => Inertia::defer(fn () => PurposeConsent::with(['lead' => function ($query) use ($dealId) {
                 $query->where('lead_id', $dealId)->orderByDesc('created_at');
-            }])->get()),
-            'gdprSetting' => Inertia::defer(fn () => GdprSetting::first()),
-            'tasks' => Inertia::defer(fn () => $deal->tasks()
-                ->with(['users', 'category', 'boardColumn', 'labels', 'deals', 'leads', 'properties'])
-                ->orderBy('id', 'desc')
-                ->get()),
-            'taskCategories' => Inertia::defer(fn () => \App\Models\TaskCategory::all()),
-            'taskLabels' => Inertia::defer(fn () => \App\Models\TaskLabelList::all()),
-            'taskBoardColumns' => Inertia::defer(fn () => \App\Models\TaskboardColumn::orderBy('priority')->get()),
-            'employees' => Inertia::defer(fn () => User::allEmployees()),
-            'projects' => Inertia::defer(fn () => \App\Models\Project::all()),
-            'leadContacts' => Inertia::defer(fn () => Lead::allLeads()),
+            }])->get(), 'timeline'),
+            'gdprSetting' => Inertia::defer(fn () => GdprSetting::first(), 'timeline'),
+            'taskCategories' => Inertia::defer(fn () => \App\Models\TaskCategory::all(), 'taskMeta'),
+            'taskLabels' => Inertia::defer(fn () => \App\Models\TaskLabelList::all(), 'taskMeta'),
+            'taskBoardColumns' => Inertia::defer(fn () => \App\Models\TaskboardColumn::orderBy('priority')->get(), 'taskMeta'),
+            'employees' => Inertia::defer(fn () => User::allEmployees(), 'formMeta'),
+            'projects' => Inertia::defer(fn () => \App\Models\Project::all(), 'formMeta'),
+            'leadContacts' => Inertia::defer(fn () => Lead::allLeads(), 'formMeta'),
             'nonActiveLeadAgents' => Inertia::defer(fn () => LeadAgent::with('user')->whereHas('user', function ($q) {
                 $q->where('status', '!=', 'active');
-            })->get()),
+            })->get(), 'formMeta'),
             'pipelineCustomFieldCategoryIdsByPipeline' => Inertia::defer(function () {
                 return LeadPipeline::query()
                     ->with('customFieldCategories:id')
@@ -792,8 +746,49 @@ class DealController extends AccountBaseController
                         ];
                     })
                     ->toArray();
-            }),
+            }, 'formMeta'),
         ]));
+    }
+
+    /**
+     * JSON endpoint for the meetings/follow-ups tab — fetched independently by
+     * the frontend instead of riding the page's deferred-prop bundle. Logic
+     * relocated verbatim from the former `dealFollowUps` deferred prop.
+     */
+    public function dealMeetings(Request $request, $id)
+    {
+        $deal = Deal::findOrFail($id);
+        $dealRules = [
+            'added' => 'added_by',
+            'owned' => fn ($user, $deal) => $deal->isVisibleToUser($user->id),
+        ];
+        $access = PermissionService::checkAccess(user(), 'view_deals', $deal, $dealRules);
+        abort_403(!$access['canAccess']);
+
+        $dealFollowUps = DealFollowUp::with(['addedBy:id,name,image', 'meetingType', 'meetingSummary'])
+            ->where('deal_id', $id)
+            ->orderBy('next_follow_up_date', 'desc')
+            ->get();
+
+        $allParticipantIds = $dealFollowUps->flatMap(fn ($f) => $f->participants ?? [])->unique()->values();
+        $participantUsersMap = $allParticipantIds->isEmpty()
+            ? collect()
+            : User::whereIn('id', $allParticipantIds)->get(['id', 'name', 'image'])->keyBy('id');
+
+        $dealFollowUps->each(function ($f) use ($participantUsersMap) {
+            $f->participant_users = collect($f->participants ?? [])
+                ->map(fn ($pid) => $participantUsersMap->get($pid))
+                ->filter()
+                ->map(fn ($u) => [
+                    'id' => $u->id,
+                    'name' => $u->name,
+                    'image' => $u->image ? $u->image_url : null,
+                ])
+                ->values()
+                ->toArray();
+        });
+
+        return response()->json(['status' => 'success', 'data' => $dealFollowUps]);
     }
 
     private function prepareNotesTab(int $dealId): void
@@ -1243,9 +1238,6 @@ class DealController extends AccountBaseController
                     Package::whereIn('id', $newPackageIds)->pluck('name', 'id')->toArray()
                 );
             }
-        } else {
-            $deal->packages()->detach();
-        }
         }
 
         // Handle deal watchers

--- a/app/Http/Controllers/DealNoteController.php
+++ b/app/Http/Controllers/DealNoteController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\StoreDealNote;
 use App\Models\DealNote;
 use App\Models\Deal;
 use App\Models\User;
+use App\Services\PermissionService;
 use App\Traits\RecordsCrmEvents;
 use Illuminate\Http\Request;
 
@@ -30,6 +31,39 @@ class DealNoteController extends AccountBaseController
         abort_403(!(in_array(user()->permission('view_deal_note'), ['all', 'added'])));
 
         return $dataTable->render('leads.notes.index', $this->data);
+    }
+
+    /**
+     * JSON endpoint for the notes tab — fetched independently by the frontend
+     * instead of riding the deal page's deferred-prop bundle. Logic relocated
+     * verbatim from the former `notes` deferred prop on DealController::show().
+     */
+    public function dealNotes(Request $request, $dealId)
+    {
+        $deal = Deal::findOrFail($dealId);
+        $dealRules = [
+            'added' => 'added_by',
+            'owned' => fn ($user, $deal) => $deal->isVisibleToUser($user->id),
+        ];
+        $access = PermissionService::checkAccess(user(), 'view_deals', $deal, $dealRules);
+        abort_403(!$access['canAccess']);
+
+        $notes = DealNote::with('addedBy')
+            ->where('deal_id', $dealId)
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $viewNotesPermission = user()->permission('view_deal_note');
+
+        if ($viewNotesPermission == 'none') {
+            $notes = collect();
+        } elseif ($viewNotesPermission == 'added') {
+            $notes = $notes->where('added_by', user()->id)->values();
+        } elseif ($viewNotesPermission == 'owned') {
+            $notes = $notes->where('added_by', '!=', user()->id)->values();
+        }
+
+        return response()->json(['status' => 'success', 'data' => $notes]);
     }
 
     public function create()

--- a/app/Http/Controllers/LeadFileController.php
+++ b/app/Http/Controllers/LeadFileController.php
@@ -6,6 +6,7 @@ use App\Helper\Reply;
 use App\Models\Deal;
 use App\Models\DealFile;
 use App\Services\FileStorageService;
+use App\Services\PermissionService;
 use App\Traits\IconTrait;
 use Illuminate\Http\Request;
 use App\Helper\Files;
@@ -186,6 +187,29 @@ class LeadFileController extends AccountBaseController
 
         return Reply::success(__('messages.deleteSuccess'));
 
+    }
+
+    /**
+     * JSON endpoint for the files tab — fetched independently by the frontend
+     * instead of riding the deal page's deferred-prop bundle. Logic relocated
+     * verbatim from the former `files` deferred prop on DealController::show().
+     */
+    public function dealFiles(Request $request, $dealId)
+    {
+        $deal = Deal::findOrFail($dealId);
+        $dealRules = [
+            'added' => 'added_by',
+            'owned' => fn ($user, $deal) => $deal->isVisibleToUser($user->id),
+        ];
+        $access = PermissionService::checkAccess(user(), 'view_deals', $deal, $dealRules);
+        abort_403(!$access['canAccess']);
+
+        $files = $deal->files()->orderBy('created_at', 'desc')->get();
+        if (user()->permission('view_lead_files') == 'added') {
+            $files = $files->where('added_by', user()->id)->values();
+        }
+
+        return response()->json(['status' => 'success', 'data' => $files]);
     }
 
     /**

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -372,6 +372,30 @@ class TaskController extends AccountBaseController
     }
 
     /**
+     * JSON endpoint for a deal's tasks tab — fetched independently by the
+     * frontend instead of riding the deal page's deferred-prop bundle. Logic
+     * relocated verbatim from the former `tasks` deferred prop on
+     * DealController::show().
+     */
+    public function dealTasks(Request $request, $dealId)
+    {
+        $deal = Deal::findOrFail($dealId);
+        $dealRules = [
+            'added' => 'added_by',
+            'owned' => fn ($user, $deal) => $deal->isVisibleToUser($user->id),
+        ];
+        $access = PermissionService::checkAccess(user(), 'view_deals', $deal, $dealRules);
+        abort_403(!$access['canAccess']);
+
+        $tasks = $deal->tasks()
+            ->with(['users', 'category', 'boardColumn', 'labels', 'deals', 'leads', 'properties'])
+            ->orderBy('id', 'desc')
+            ->get();
+
+        return response()->json(['status' => 'success', 'data' => $tasks]);
+    }
+
+    /**
      * XXXXXXXXXXX
      *
      * @return array

--- a/app/Services/DealGatheringService.php
+++ b/app/Services/DealGatheringService.php
@@ -509,5 +509,4 @@ class DealGatheringService
 
         return $key;
     }
-    }
 }

--- a/resources/js/Pages/Deals/Redesign/DealViewRedesign.tsx
+++ b/resources/js/Pages/Deals/Redesign/DealViewRedesign.tsx
@@ -38,13 +38,7 @@ import { DealWorkspaceProvider, useDealWorkspace } from "./context/DealWorkspace
 
 export default function DealViewRedesign(props: DealShowProps) {
     return (
-        <DealWorkspaceProvider
-            deal={props.deal}
-            notes={props.notes}
-            tasks={props.tasks}
-            dealFollowUps={props.dealFollowUps}
-            files={props.files}
-        >
+        <DealWorkspaceProvider deal={props.deal}>
             <DealViewRedesignInner {...props} />
         </DealWorkspaceProvider>
     );
@@ -70,7 +64,17 @@ function DealViewRedesignInner(props: DealShowProps) {
     const { refresh, isRefreshing } = usePageRefresh({
         canRefresh: () => !isDealEditMode,
     });
-    const { deal, notes, tasks, dealFollowUps, files } = useDealWorkspace();
+    const {
+        deal,
+        notes,
+        notesLoading,
+        tasks,
+        tasksLoading,
+        dealFollowUps,
+        dealFollowUpsLoading,
+        files,
+        filesLoading,
+    } = useDealWorkspace();
     const pageTitle = props?.pageTitle || deal?.name;
     const { t, locale } = useTranslation();
     // Adapters are plain functions with no hook access, so publish the active
@@ -144,23 +148,21 @@ function DealViewRedesignInner(props: DealShowProps) {
 
     const counts = useMemo(
         () => ({
-            notes: props.notes === undefined ? undefined : notes.length,
-            tasks:
-                props.tasks === undefined ? undefined : overview.openTasksCount,
-            meetings:
-                props.dealFollowUps === undefined
-                    ? undefined
-                    : overview.upcomingMeetingsCount,
-            files: props.files === undefined ? undefined : files.length,
+            notes: notesLoading ? undefined : notes.length,
+            tasks: tasksLoading ? undefined : overview.openTasksCount,
+            meetings: dealFollowUpsLoading
+                ? undefined
+                : overview.upcomingMeetingsCount,
+            files: filesLoading ? undefined : files.length,
             offers: offersCount,
             recommendations: recommendationsCount,
             itinerary: deal.lead_flight_itineraries?.length ?? 0,
         }),
         [
-            props.notes,
-            props.tasks,
-            props.dealFollowUps,
-            props.files,
+            notesLoading,
+            tasksLoading,
+            dealFollowUpsLoading,
+            filesLoading,
             notes.length,
             files.length,
             deal.lead_flight_itineraries?.length,
@@ -249,55 +251,62 @@ function DealViewRedesignInner(props: DealShowProps) {
                                     <div className="p-4">
                                         {activeTab === "overview" && (
                                             <Deferred
-                                                data={[
-                                                    "notes",
-                                                    "tasks",
-                                                    "dealFollowUps",
-                                                    "taskBoardColumns",
-                                                ]}
+                                                data="taskBoardColumns"
                                                 fallback={<OverviewDeferredSkeleton />}
                                             >
-                                                <WorkspaceOverviewTab
-                                                    deal={deal}
-                                                    notes={notes}
-                                                    tasks={tasks}
-                                                    dealFollowUps={dealFollowUps}
-                                                    taskBoardColumns={taskBoardColumns}
-                                                    permissions={permissions}
-                                                    meetingTypes={meetingTypes}
-                                                    onNavigateToSubTab={nav.setTab}
-                                                    onAddTask={() => setAddTaskOpen(true)}
-                                                    onAddMeeting={() => setAddMeetingOpen(true)}
-                                                    onAddNote={() => setAddNoteOpen(true)}
-                                                />
+                                                {notesLoading ||
+                                                tasksLoading ||
+                                                dealFollowUpsLoading ? (
+                                                    <OverviewDeferredSkeleton />
+                                                ) : (
+                                                    <WorkspaceOverviewTab
+                                                        deal={deal}
+                                                        notes={notes}
+                                                        tasks={tasks}
+                                                        dealFollowUps={dealFollowUps}
+                                                        taskBoardColumns={taskBoardColumns}
+                                                        permissions={permissions}
+                                                        meetingTypes={meetingTypes}
+                                                        onNavigateToSubTab={nav.setTab}
+                                                        onAddTask={() => setAddTaskOpen(true)}
+                                                        onAddMeeting={() =>
+                                                            setAddMeetingOpen(true)
+                                                        }
+                                                        onAddNote={() => setAddNoteOpen(true)}
+                                                    />
+                                                )}
                                             </Deferred>
                                         )}
-                                        {activeTab === "notes" && (
-                                            <Deferred data="notes" fallback={<TabDeferredSkeleton />}>
+                                        {activeTab === "notes" &&
+                                            (notesLoading ? (
+                                                <TabDeferredSkeleton />
+                                            ) : (
                                                 <WorkspaceNotesTab
                                                     notes={notes}
                                                     permissions={permissions}
                                                 />
-                                            </Deferred>
-                                        )}
+                                            ))}
                                         {activeTab === "tasks" && (
                                             <Deferred
-                                                data={["tasks", "taskBoardColumns"]}
+                                                data="taskBoardColumns"
                                                 fallback={<TabDeferredSkeleton />}
                                             >
-                                                <WorkspaceTasksTab
-                                                    tasks={tasks}
-                                                    taskBoardColumns={taskBoardColumns}
-                                                    permissions={permissions}
-                                                    onAddTask={() => setAddTaskOpen(true)}
-                                                />
+                                                {tasksLoading ? (
+                                                    <TabDeferredSkeleton />
+                                                ) : (
+                                                    <WorkspaceTasksTab
+                                                        tasks={tasks}
+                                                        taskBoardColumns={taskBoardColumns}
+                                                        permissions={permissions}
+                                                        onAddTask={() => setAddTaskOpen(true)}
+                                                    />
+                                                )}
                                             </Deferred>
                                         )}
-                                        {activeTab === "meetings" && (
-                                            <Deferred
-                                                data="dealFollowUps"
-                                                fallback={<TabDeferredSkeleton />}
-                                            >
+                                        {activeTab === "meetings" &&
+                                            (dealFollowUpsLoading ? (
+                                                <TabDeferredSkeleton />
+                                            ) : (
                                                 <WorkspaceMeetingsTab
                                                     deal={deal}
                                                     followUps={dealFollowUps}
@@ -307,10 +316,11 @@ function DealViewRedesignInner(props: DealShowProps) {
                                                         setAddMeetingOpen(true)
                                                     }
                                                 />
-                                            </Deferred>
-                                        )}
-                                        {activeTab === "files" && (
-                                            <Deferred data="files" fallback={<TabDeferredSkeleton />}>
+                                            ))}
+                                        {activeTab === "files" &&
+                                            (filesLoading ? (
+                                                <TabDeferredSkeleton />
+                                            ) : (
                                                 <WorkspaceFilesTab
                                                     deal={deal}
                                                     files={files}
@@ -318,8 +328,7 @@ function DealViewRedesignInner(props: DealShowProps) {
                                                     fields={fields}
                                                     categoryIds={pipelineCategoryIds}
                                                 />
-                                            </Deferred>
-                                        )}
+                                            ))}
                                         {activeTab === "offers" && (
                                             <WorkspaceOffersTab
                                                 deal={deal}

--- a/resources/js/Pages/Deals/Redesign/context/DealWorkspaceContext.tsx
+++ b/resources/js/Pages/Deals/Redesign/context/DealWorkspaceContext.tsx
@@ -3,83 +3,127 @@ import {
     useContext,
     useEffect,
     useMemo,
+    useRef,
     useState,
     type Dispatch,
     type ReactNode,
     type SetStateAction,
 } from "react";
+import { useApiQuery } from "@/lib/api/client";
 import type { Deal } from "@/Types/api/deals";
 import type { DealFile } from "@/Types/api/file";
 import type { DealFollowup } from "@/Types/api/deal-followup";
 import type { Note } from "@/Types/api/note";
 import type { Task } from "@/Types/api/tasks";
 
+interface EntityResponse<T> {
+    status: string;
+    data: T;
+}
+
 interface DealWorkspaceValue {
     deal: Deal;
     setDeal: Dispatch<SetStateAction<Deal>>;
     notes: Note[];
     setNotes: Dispatch<SetStateAction<Note[]>>;
+    notesLoading: boolean;
     tasks: Task[];
     setTasks: Dispatch<SetStateAction<Task[]>>;
+    tasksLoading: boolean;
     dealFollowUps: DealFollowup[];
     setDealFollowUps: Dispatch<SetStateAction<DealFollowup[]>>;
+    dealFollowUpsLoading: boolean;
     files: DealFile[];
     setFiles: Dispatch<SetStateAction<DealFile[]>>;
+    filesLoading: boolean;
 }
 
 const DealWorkspaceContext = createContext<DealWorkspaceValue | null>(null);
 
 interface DealWorkspaceProviderProps {
     deal: Deal;
-    notes?: Note[];
-    tasks?: Task[];
-    dealFollowUps?: DealFollowup[];
-    files?: DealFile[];
     children: ReactNode;
 }
 
 /**
- * Holds the deal + its deferred relations as local React state so mutations
- * can patch them directly from a REST response instead of an Inertia reload.
- * Deferred props (notes/tasks/dealFollowUps/files) arrive as `undefined` and
- * are copied into local state the moment Inertia resolves them; after that,
- * local state is the source of truth and no longer re-synced from props.
+ * Holds the deal + its notes/tasks/meetings/files as local React state so
+ * mutations can patch them directly from a REST response instead of an
+ * Inertia reload. Each entity is fetched independently via its own JSON
+ * endpoint (deals.notes.index / deals.tasks.index / deals.meetings.index /
+ * deals.files.index) exactly like offers/recommendations already do, instead
+ * of riding the page's Inertia deferred-prop bundle — one slow/broken fetch
+ * can no longer stall the others. Each query's data seeds local state once;
+ * after that, local state is the source of truth and mutations (not
+ * background refetches) keep it current.
  */
 export function DealWorkspaceProvider({
     deal: initialDeal,
-    notes: initialNotes,
-    tasks: initialTasks,
-    dealFollowUps: initialDealFollowUps,
-    files: initialFiles,
     children,
 }: DealWorkspaceProviderProps) {
     const [deal, setDeal] = useState<Deal>(initialDeal);
-    const [notes, setNotes] = useState<Note[]>(initialNotes ?? []);
-    const [tasks, setTasks] = useState<Task[]>(initialTasks ?? []);
-    const [dealFollowUps, setDealFollowUps] = useState<DealFollowup[]>(
-        initialDealFollowUps ?? [],
-    );
-    const [files, setFiles] = useState<DealFile[]>(initialFiles ?? []);
-
     useEffect(() => {
         setDeal(initialDeal);
     }, [initialDeal]);
 
-    useEffect(() => {
-        if (initialNotes !== undefined) setNotes(initialNotes);
-    }, [initialNotes]);
+    const notesQuery = useApiQuery<EntityResponse<Note[]>>({
+        path: route("deals.notes.index", deal.id),
+        options: { staleTime: 30_000 },
+    });
+    const tasksQuery = useApiQuery<EntityResponse<Task[]>>({
+        path: route("deals.tasks.index", deal.id),
+        options: { staleTime: 30_000 },
+    });
+    const dealFollowUpsQuery = useApiQuery<EntityResponse<DealFollowup[]>>({
+        path: route("deals.meetings.index", deal.id),
+        options: { staleTime: 30_000 },
+    });
+    const filesQuery = useApiQuery<EntityResponse<DealFile[]>>({
+        path: route("deals.files.index", deal.id),
+        options: { staleTime: 30_000 },
+    });
+
+    const [notes, setNotes] = useState<Note[]>([]);
+    const [tasks, setTasks] = useState<Task[]>([]);
+    const [dealFollowUps, setDealFollowUps] = useState<DealFollowup[]>([]);
+    const [files, setFiles] = useState<DealFile[]>([]);
+
+    // Seed local state the first time each query resolves; later background
+    // refetches (e.g. on window refocus) must not clobber in-progress
+    // mutations, so this only fires once per entity.
+    const seeded = useRef({
+        notes: false,
+        tasks: false,
+        dealFollowUps: false,
+        files: false,
+    });
 
     useEffect(() => {
-        if (initialTasks !== undefined) setTasks(initialTasks);
-    }, [initialTasks]);
+        if (!seeded.current.notes && notesQuery.data?.data) {
+            setNotes(notesQuery.data.data);
+            seeded.current.notes = true;
+        }
+    }, [notesQuery.data]);
 
     useEffect(() => {
-        if (initialDealFollowUps !== undefined) setDealFollowUps(initialDealFollowUps);
-    }, [initialDealFollowUps]);
+        if (!seeded.current.tasks && tasksQuery.data?.data) {
+            setTasks(tasksQuery.data.data);
+            seeded.current.tasks = true;
+        }
+    }, [tasksQuery.data]);
 
     useEffect(() => {
-        if (initialFiles !== undefined) setFiles(initialFiles);
-    }, [initialFiles]);
+        if (!seeded.current.dealFollowUps && dealFollowUpsQuery.data?.data) {
+            setDealFollowUps(dealFollowUpsQuery.data.data);
+            seeded.current.dealFollowUps = true;
+        }
+    }, [dealFollowUpsQuery.data]);
+
+    useEffect(() => {
+        if (!seeded.current.files && filesQuery.data?.data) {
+            setFiles(filesQuery.data.data);
+            seeded.current.files = true;
+        }
+    }, [filesQuery.data]);
 
     const value = useMemo<DealWorkspaceValue>(
         () => ({
@@ -87,14 +131,28 @@ export function DealWorkspaceProvider({
             setDeal,
             notes,
             setNotes,
+            notesLoading: notesQuery.isLoading,
             tasks,
             setTasks,
+            tasksLoading: tasksQuery.isLoading,
             dealFollowUps,
             setDealFollowUps,
+            dealFollowUpsLoading: dealFollowUpsQuery.isLoading,
             files,
             setFiles,
+            filesLoading: filesQuery.isLoading,
         }),
-        [deal, notes, tasks, dealFollowUps, files],
+        [
+            deal,
+            notes,
+            tasks,
+            dealFollowUps,
+            files,
+            notesQuery.isLoading,
+            tasksQuery.isLoading,
+            dealFollowUpsQuery.isLoading,
+            filesQuery.isLoading,
+        ],
     );
 
     return (

--- a/resources/js/Pages/Deals/Redesign/types.ts
+++ b/resources/js/Pages/Deals/Redesign/types.ts
@@ -1,11 +1,7 @@
 import type { PageProps } from "@/Components/DashboardLayout";
 import type { DealSummaryPayload } from "@/Types/entity-summary";
 import type { Deal } from "@/Types/api/deals";
-import type { DealFile } from "@/Types/api/file";
-import type { DealFollowup } from "@/Types/api/deal-followup";
-import type { Note } from "@/Types/api/note";
 import type { Proposal } from "@/Types/api/proposal";
-import type { Task } from "@/Types/api/tasks";
 
 /**
  * v2.2 uses a single flat tab bar: record tabs, then a divider, then meta tabs.
@@ -58,15 +54,14 @@ export interface DealShowProps extends PageProps {
     pageTitle: string;
     dealAiSummary?: DealSummaryPayload | null;
     restrictPackageOrProperty?: boolean;
+    // notes / dealFollowUps / files / tasks fetch independently via
+    // deals.notes.index / deals.meetings.index / deals.files.index /
+    // deals.tasks.index (see DealWorkspaceContext) — no longer page props.
     // C1 deferred — may be undefined until Inertia resolves them
-    notes?: Note[];
-    dealFollowUps?: DealFollowup[];
-    files?: DealFile[];
     proposals?: Proposal[];
     histories?: any[];
     consents?: any[];
     gdprSetting?: any;
-    tasks?: Task[];
     taskCategories?: any[];
     taskLabels?: any[];
     taskBoardColumns?: any[];

--- a/routes/web.php
+++ b/routes/web.php
@@ -1287,6 +1287,13 @@ Route::get('meeting-summary/{summaryId}', [MeetingSummaryController::class, 'sho
         Route::delete('/', [App\Http\Controllers\OfferController::class, 'removeFromDeal'])->name('remove');
     });
 
+    // Deal workspace tabs — each fetched independently by the frontend (not
+    // Inertia deferred props) so a slow/broken one can't stall the others.
+    Route::get('deals/{dealId}/notes', [DealNoteController::class, 'dealNotes'])->name('deals.notes.index');
+    Route::get('deals/{dealId}/tasks', [TaskController::class, 'dealTasks'])->name('deals.tasks.index');
+    Route::get('deals/{dealId}/meetings', [DealController::class, 'dealMeetings'])->name('deals.meetings.index');
+    Route::get('deals/{dealId}/files', [LeadFileController::class, 'dealFiles'])->name('deals.files.index');
+
     // Property Asset Management (New System)
     Route::get('property-assets/options', [App\Http\Controllers\PropertyAssetController::class, 'getAssetOptions'])->name('properties.assets.options');
     Route::prefix('properties/{property}/assets')->name('properties.assets.')->group(function () {


### PR DESCRIPTION
…les independently

- Updated DealController, DealNoteController, LeadFileController, and TaskController to implement new JSON endpoints for notes, tasks, meetings, and files, allowing independent fetching by the frontend.
- Removed deferred props for these entities from the DealController to prevent slow requests from blocking others.
- Enhanced DealWorkspaceContext to manage loading states for each entity, improving user experience during data retrieval.
- Adjusted DealViewRedesign to accommodate the new fetching strategy, ensuring a smoother interaction with the deal workspace.