### PR TITLE
feat: add 'hide all categories' feature to lead pipelines

### DIFF
--- a/app/Http/Controllers/LeadPipelineSettingController.php
+++ b/app/Http/Controllers/LeadPipelineSettingController.php
@@ -83,6 +83,7 @@ class LeadPipelineSettingController extends AccountBaseController
             ->firstOrFail();
         $pipeline->name = $request->name;
         $pipeline->label_color = $request->label_color;
+        $pipeline->hide_all_categories = $request->boolean('hide_all_categories');
         $pipeline->save();
 
         $validated = $request->validated();

--- a/app/Http/Controllers/LeadPipelineSettingController.php
+++ b/app/Http/Controllers/LeadPipelineSettingController.php
@@ -81,10 +81,6 @@ class LeadPipelineSettingController extends AccountBaseController
         $pipeline = LeadPipeline::where('company_id', company()->id)
             ->where('id', $id)
             ->firstOrFail();
-        $pipeline->name = $request->name;
-        $pipeline->label_color = $request->label_color;
-        $pipeline->hide_all_categories = $request->boolean('hide_all_categories');
-        $pipeline->save();
 
         $validated = $request->validated();
         $categoryScopes = $validated['category_scopes'] ?? [];
@@ -95,10 +91,18 @@ class LeadPipelineSettingController extends AccountBaseController
             ];
         }
 
-        $this->scopeResolver->syncCategoryScopes($pipeline, $categoryScopes);
-
         $fieldScopes = $validated['field_scopes'] ?? $request->input('field_scopes', []);
-        $this->syncFieldScopes($pipeline, is_array($fieldScopes) ? $fieldScopes : []);
+        $fieldScopes = is_array($fieldScopes) ? $fieldScopes : [];
+
+        DB::transaction(function () use ($request, $pipeline, $categoryScopes, $fieldScopes) {
+            $pipeline->name = $request->name;
+            $pipeline->label_color = $request->label_color;
+            $pipeline->hide_all_categories = $request->boolean('hide_all_categories');
+            $pipeline->save();
+
+            $this->scopeResolver->syncCategoryScopes($pipeline, $categoryScopes);
+            $this->syncFieldScopes($pipeline, $fieldScopes);
+        });
 
         return Reply::success(__('messages.updateSuccess'));
     }

--- a/app/Http/Requests/LeadSetting/UpdateLeadPipeline.php
+++ b/app/Http/Requests/LeadSetting/UpdateLeadPipeline.php
@@ -35,6 +35,7 @@ class UpdateLeadPipeline extends CoreRequest
         return [
             'name' => 'required|unique:lead_pipelines,name,'.$this->route('lead_pipeline_setting').',id,company_id,' . company()->id,
             'label_color' => 'required',
+            'hide_all_categories' => 'nullable|boolean',
             'category_ids' => 'nullable|array',
             'category_ids.*' => $categoryRule,
             'category_scopes' => 'nullable|array',

--- a/app/Models/LeadPipeline.php
+++ b/app/Models/LeadPipeline.php
@@ -54,6 +54,7 @@ class LeadPipeline extends BaseModel
 
     protected $casts = [
         'hidden_from_nav' => 'boolean',
+        'hide_all_categories' => 'boolean',
     ];
 
     public function scopeVisibleInNav($query)

--- a/app/Services/PipelineScopeResolverService.php
+++ b/app/Services/PipelineScopeResolverService.php
@@ -71,11 +71,11 @@ class PipelineScopeResolverService
             return null;
         }
 
-        if ($this->pipelineHidesAllCategories($pipelineId)) {
+        $companyId = $companyId ?? company()?->id;
+
+        if ($this->pipelineHidesAllCategories($pipelineId, $companyId)) {
             return [];
         }
-
-        $companyId = $companyId ?? company()?->id;
 
         $scopesQuery = CustomFieldCategoryScope::query()
             ->where('pipeline_id', $pipelineId);
@@ -144,11 +144,11 @@ class PipelineScopeResolverService
             return null;
         }
 
-        if ($this->pipelineHidesAllCategories($pipelineId)) {
+        $companyId = $companyId ?? company()?->id;
+
+        if ($this->pipelineHidesAllCategories($pipelineId, $companyId)) {
             return [];
         }
-
-        $companyId = $companyId ?? company()?->id;
 
         $scopesQuery = CustomFieldCategoryScope::query()
             ->where('pipeline_id', $pipelineId);
@@ -239,14 +239,22 @@ class PipelineScopeResolverService
     /**
      * Whether a pipeline is configured to hide all custom field categories,
      * overriding any category_scopes rows (pipeline-wide or per-stage).
+     *
+     * When $companyId is given, the pipeline must belong to that company —
+     * a mismatched pipeline/company pair (stale or cross-tenant data) returns
+     * false so callers fall through to their existing "show all" behavior
+     * instead of hiding categories based on the wrong company's setting.
      */
-    public function pipelineHidesAllCategories(?int $pipelineId): bool
+    public function pipelineHidesAllCategories(?int $pipelineId, ?int $companyId = null): bool
     {
         if (!$pipelineId) {
             return false;
         }
 
-        return (bool) LeadPipeline::where('id', $pipelineId)->value('hide_all_categories');
+        return (bool) LeadPipeline::query()
+            ->where('id', $pipelineId)
+            ->when($companyId, fn ($q) => $q->where('company_id', $companyId))
+            ->value('hide_all_categories');
     }
 
     /**

--- a/app/Services/PipelineScopeResolverService.php
+++ b/app/Services/PipelineScopeResolverService.php
@@ -71,6 +71,10 @@ class PipelineScopeResolverService
             return null;
         }
 
+        if ($this->pipelineHidesAllCategories($pipelineId)) {
+            return [];
+        }
+
         $companyId = $companyId ?? company()?->id;
 
         $scopesQuery = CustomFieldCategoryScope::query()
@@ -138,6 +142,10 @@ class PipelineScopeResolverService
     {
         if (!$pipelineId) {
             return null;
+        }
+
+        if ($this->pipelineHidesAllCategories($pipelineId)) {
+            return [];
         }
 
         $companyId = $companyId ?? company()?->id;
@@ -226,6 +234,39 @@ class PipelineScopeResolverService
         }
 
         return $query->get();
+    }
+
+    /**
+     * Whether a pipeline is configured to hide all custom field categories,
+     * overriding any category_scopes rows (pipeline-wide or per-stage).
+     */
+    public function pipelineHidesAllCategories(?int $pipelineId): bool
+    {
+        if (!$pipelineId) {
+            return false;
+        }
+
+        return (bool) LeadPipeline::where('id', $pipelineId)->value('hide_all_categories');
+    }
+
+    /**
+     * Pipeline IDs (for the company) configured to hide all custom field
+     * categories. Exposed to the frontend so client-resolved scope maps
+     * (SaveDealModal / legacy DealInfoSection) can honor the same override.
+     *
+     * @return array<int>
+     */
+    public function getHideAllCategoriesPipelineIds(?int $companyId = null): array
+    {
+        $companyId = $companyId ?? company()?->id;
+
+        return LeadPipeline::query()
+            ->where('hide_all_categories', true)
+            ->when($companyId, fn ($q) => $q->where('company_id', $companyId))
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Traits/DealFormDataTrait.php
+++ b/app/Traits/DealFormDataTrait.php
@@ -76,6 +76,10 @@ trait DealFormDataTrait
             company()->id
         );
 
+        $hideAllCategoriesPipelineIds = $scopeResolver->getHideAllCategoriesPipelineIds(
+            company()->id
+        );
+
         $packageSettings = $packageRouter->getDealPackageSettings();
 
         return [
@@ -100,6 +104,7 @@ trait DealFormDataTrait
             'pipelineCustomFieldCategoryIdsByPipeline' => $pipelineCustomFieldCategoryIdsByPipeline,
             'pipelineCategoryScopeMap' => $pipelineCategoryScopeMap,
             'pipelineFieldScopeMap' => $pipelineFieldScopeMap,
+            'hideAllCategoriesPipelineIds' => $hideAllCategoriesPipelineIds,
             'packagePipelineRoutingEnabled' => $packageSettings['packagePipelineRoutingEnabled'],
             'dealPackageMode' => $packageSettings['dealPackageMode'],
         ];

--- a/database/migrations/2026_07_29_100000_add_hide_all_categories_to_lead_pipelines_table.php
+++ b/database/migrations/2026_07_29_100000_add_hide_all_categories_to_lead_pipelines_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lead_pipelines', function (Blueprint $table) {
+            $table->boolean('hide_all_categories')->default(false)->after('hidden_from_nav');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lead_pipelines', function (Blueprint $table) {
+            $table->dropColumn('hide_all_categories');
+        });
+    }
+};

--- a/resources/js/Features/Deals/SaveDeal/DealForm.tsx
+++ b/resources/js/Features/Deals/SaveDeal/DealForm.tsx
@@ -79,6 +79,10 @@ const DealForm: React.FC<DealFormProps> = ({
         formReferenceData.pipelineFieldScopeMap ||
         props.pipelineFieldScopeMap ||
         {};
+    const hideAllCategoriesPipelineIds: Array<number | string> =
+        formReferenceData.hideAllCategoriesPipelineIds ||
+        props.hideAllCategoriesPipelineIds ||
+        [];
     const stages = formReferenceData.stages || props.stages || [];
     const { mode: fieldViewMode, setMode: setFieldViewMode, showAllFields } =
         useDealFieldViewMode();
@@ -107,6 +111,8 @@ const DealForm: React.FC<DealFormProps> = ({
                 allCustomFieldCategories,
                 pipelineCategoryScopeMap,
                 selectedPipelineId,
+                null,
+                hideAllCategoriesPipelineIds,
             );
         }
 
@@ -116,6 +122,8 @@ const DealForm: React.FC<DealFormProps> = ({
             selectedPipelineId,
             selectedStageId,
             stages,
+            null,
+            hideAllCategoriesPipelineIds,
         );
     }, [
         showAllFields,
@@ -124,6 +132,7 @@ const DealForm: React.FC<DealFormProps> = ({
         allCustomFieldCategories,
         pipelineCategoryScopeMap,
         stages,
+        hideAllCategoriesPipelineIds,
     ]);
 
     useEffect(() => {

--- a/resources/js/Features/Deals/pipelineScopeUtils.ts
+++ b/resources/js/Features/Deals/pipelineScopeUtils.ts
@@ -69,6 +69,26 @@ function normalizePipelineId(id: number | string | undefined | null): number | n
     return Number.isFinite(normalized) ? normalized : null;
 }
 
+/**
+ * Pipeline-level "Show none" override — set in Pipeline Settings, it hides
+ * every custom field category for the pipeline regardless of any pipeline-wide
+ * or per-stage category_scopes rows. Must be checked before any scope-map
+ * resolution so it wins outright even when scopes are still configured.
+ */
+function pipelineHidesAllCategories(
+    hideAllCategoriesPipelineIds: Array<number | string> | undefined,
+    pipelineId: number | string | null | undefined,
+): boolean {
+    if (!hideAllCategoriesPipelineIds?.length || pipelineId == null) {
+        return false;
+    }
+
+    const normalized = normalizePipelineId(pipelineId);
+    return hideAllCategoriesPipelineIds.some(
+        (id) => normalizePipelineId(id) === normalized,
+    );
+}
+
 function normalizeStageId(id: number | string | undefined | null): number | null {
     return normalizePipelineId(id);
 }
@@ -473,7 +493,12 @@ export function filterCategoriesByScope<T extends { id: number }>(
     stageId?: number,
     stages?: PipelineStageLike[],
     fallbackIds?: number[] | null,
+    hideAllCategoriesPipelineIds?: Array<number | string>,
 ): T[] {
+    if (pipelineHidesAllCategories(hideAllCategoriesPipelineIds, pipelineId)) {
+        return [];
+    }
+
     const clientIds = resolveScopedCategoryIds(
         scopeMap,
         pipelineId,
@@ -515,7 +540,12 @@ export function filterCategoriesForAllFieldsView<T extends { id: number }>(
     scopeMap: Record<string, ScopeByStageMap>,
     pipelineId?: number,
     fallbackIds?: number[] | null,
+    hideAllCategoriesPipelineIds?: Array<number | string>,
 ): T[] {
+    if (pipelineHidesAllCategories(hideAllCategoriesPipelineIds, pipelineId)) {
+        return [];
+    }
+
     const clientIds = resolveAllPipelineCategoryIds(scopeMap, pipelineId);
 
     const pipelineScope =

--- a/resources/js/Pages/Deals/Components/DealInfoSection.tsx
+++ b/resources/js/Pages/Deals/Components/DealInfoSection.tsx
@@ -108,6 +108,7 @@ export default function DealInfoSection({
 
     const pipelineCategoryScopeMap = props.pipelineCategoryScopeMap || {};
     const pipelineFieldScopeMap = props.pipelineFieldScopeMap || {};
+    const hideAllCategoriesPipelineIds = props.hideAllCategoriesPipelineIds || [];
     const stages = props.stages || [];
     const scopedCategoryIdsFromServer =
         props.scopedCustomFieldCategoryIds ?? null;
@@ -147,6 +148,7 @@ export default function DealInfoSection({
                       pipelineCategoryScopeMap,
                       currentDeal.lead_pipeline_id,
                       allPipelineCategoryIdsFromServer,
+                      hideAllCategoriesPipelineIds,
                   )
                 : filterCategoriesByScope(
                       allCustomFieldCategories,
@@ -155,6 +157,7 @@ export default function DealInfoSection({
                       currentDeal.pipeline_stage_id,
                       stages,
                       scopedCategoryIdsFromServer,
+                      hideAllCategoriesPipelineIds,
                   ),
         [
             showAllFields,
@@ -165,6 +168,7 @@ export default function DealInfoSection({
             stages,
             scopedCategoryIdsFromServer,
             allPipelineCategoryIdsFromServer,
+            hideAllCategoriesPipelineIds,
         ],
     );
 

--- a/resources/js/Pages/Deals/Redesign/DealViewRedesign.tsx
+++ b/resources/js/Pages/Deals/Redesign/DealViewRedesign.tsx
@@ -110,6 +110,8 @@ function DealViewRedesignInner(props: DealShowProps) {
     // the legacy DealInfoSection.tsx pattern (pipelineScopeUtils.ts helpers).
     const pipelineCategoryScopeMap = pageProps.pipelineCategoryScopeMap ?? {};
     const pipelineFieldScopeMap = pageProps.pipelineFieldScopeMap ?? {};
+    const hideAllCategoriesPipelineIds =
+        pageProps.hideAllCategoriesPipelineIds ?? [];
     const stages = pageProps.stages ?? [];
     const scopedCategoryIdsFromServer =
         pageProps.scopedCustomFieldCategoryIds ?? null;
@@ -127,6 +129,7 @@ function DealViewRedesignInner(props: DealShowProps) {
                 deal.pipeline_stage_id,
                 stages,
                 scopedCategoryIdsFromServer,
+                hideAllCategoriesPipelineIds,
             ),
         [
             customFieldCategories,
@@ -135,6 +138,7 @@ function DealViewRedesignInner(props: DealShowProps) {
             deal.pipeline_stage_id,
             stages,
             scopedCategoryIdsFromServer,
+            hideAllCategoriesPipelineIds,
         ],
     );
 

--- a/resources/lang/eng/modules.php
+++ b/resources/lang/eng/modules.php
@@ -2507,6 +2507,8 @@ return array(
         'product' => 'Product',
         'assignAgent' => 'Assign Agent',
         'pipelineCategoryHint' => 'Only selected categories will be shown on deals in this pipeline. Categories assigned to earlier stages remain visible as the deal progresses. Leave all unchecked to show all categories.',
+        'hideAllCategories' => 'Show none',
+        'hideAllCategoriesHint' => 'No custom field categories will be shown on deals in this pipeline, regardless of any categories selected below.',
         'pipelineWideCategories' => 'Pipeline-wide categories',
         'stageCategories' => 'Stage categories',
         'pipelineWideFields' => 'Pipeline-wide fields',

--- a/resources/views/lead-settings/edit-pipeline-modal.blade.php
+++ b/resources/views/lead-settings/edit-pipeline-modal.blade.php
@@ -86,6 +86,20 @@
 
                         <div id="pipelineCategoriesCollapse" class="collapse">
                         <div class="bg-light rounded p-3 mb-3">
+                            <div class="custom-control custom-checkbox mb-2">
+                                <input type="checkbox" class="custom-control-input" id="hide_all_categories"
+                                    name="hide_all_categories" value="1"
+                                    @checked($pipeline->hide_all_categories)>
+                                <label class="custom-control-label" for="hide_all_categories">
+                                    @lang('modules.deal.hideAllCategories')
+                                </label>
+                            </div>
+                            <p class="f-11 text-lightest mt-1 mb-0">@lang('modules.deal.hideAllCategoriesHint')</p>
+                        </div>
+
+                        <div id="pipelineCategoriesSelection" class="{{ $pipeline->hide_all_categories ? 'opacity-50' : '' }}"
+                            style="pointer-events: {{ $pipeline->hide_all_categories ? 'none' : 'auto' }};">
+                        <div class="bg-light rounded p-3 mb-3">
                             <x-forms.label fieldId="pipeline_wide_categories" :fieldLabel="__('modules.deal.pipelineWideCategories')" />
                             <x-deal.pipeline-scope-pills
                                 inputName="category_scopes[__pipeline__][]"
@@ -110,6 +124,7 @@
                                 :searchPlaceholder="__('app.search')" />
                         </div>
                         @endforeach
+                        </div>
                         </div>
                     </div>
                     @endif
@@ -227,6 +242,13 @@
     initPipelineScopePills($('#editStatus'));
     $('#colorpicker').colorpicker({"color": "{{ $pipeline->label_color }}"});
     $(".select-picker").selectpicker();
+
+    $('#hide_all_categories').on('change', function() {
+        var checked = $(this).is(':checked');
+        $('#pipelineCategoriesSelection')
+            .toggleClass('opacity-50', checked)
+            .css('pointer-events', checked ? 'none' : 'auto');
+    });
 
     $('#save-status').click(function() {
         if (typeof window.syncPipelineScopePillsInputs === 'function') {

--- a/resources/views/lead-settings/edit-pipeline-modal.blade.php
+++ b/resources/views/lead-settings/edit-pipeline-modal.blade.php
@@ -98,7 +98,7 @@
                         </div>
 
                         <div id="pipelineCategoriesSelection" class="{{ $pipeline->hide_all_categories ? 'opacity-50' : '' }}"
-                            style="pointer-events: {{ $pipeline->hide_all_categories ? 'none' : 'auto' }};">
+                            @if($pipeline->hide_all_categories) inert @endif>
                         <div class="bg-light rounded p-3 mb-3">
                             <x-forms.label fieldId="pipeline_wide_categories" :fieldLabel="__('modules.deal.pipelineWideCategories')" />
                             <x-deal.pipeline-scope-pills
@@ -245,9 +245,12 @@
 
     $('#hide_all_categories').on('change', function() {
         var checked = $(this).is(':checked');
-        $('#pipelineCategoriesSelection')
-            .toggleClass('opacity-50', checked)
-            .css('pointer-events', checked ? 'none' : 'auto');
+        var selectionEl = document.getElementById('pipelineCategoriesSelection');
+        $(selectionEl).toggleClass('opacity-50', checked);
+        // `inert` (not pointer-events) so disabled category pills also can't
+        // receive keyboard focus, and the search dropdown (portaled to <body>
+        // on open) never gets a chance to open in the first place.
+        selectionEl.inert = checked;
     });
 
     $('#save-status').click(function() {

--- a/tests/Unit/Services/PipelineScopeResolverServiceTest.php
+++ b/tests/Unit/Services/PipelineScopeResolverServiceTest.php
@@ -207,7 +207,35 @@ class PipelineScopeResolverServiceTest extends TestCase
         // Even with real scopes configured, "hide all" overrides them entirely.
         $this->assertSame([], $resolver->resolveCategoryIds($pipeline->id, $stages[0]->id, 1));
         $this->assertSame([], $resolver->resolveAllCategoryIds($pipeline->id, 1));
-        $this->assertTrue($resolver->pipelineHidesAllCategories($pipeline->id));
+        $this->assertTrue($resolver->pipelineHidesAllCategories($pipeline->id, 1));
         $this->assertSame([$pipeline->id], $resolver->getHideAllCategoriesPipelineIds(1));
+    }
+
+    public function test_hide_all_categories_does_not_apply_across_a_mismatched_company(): void
+    {
+        [$pipeline, $stages] = $this->makePipelineWithStages(2);
+
+        CustomFieldCategoryScope::create([
+            'company_id' => 1,
+            'category_id' => 200,
+            'pipeline_id' => $pipeline->id,
+            'pipeline_stage_id' => $stages[0]->id,
+        ]);
+
+        $pipeline->company_id = 1;
+        $pipeline->hide_all_categories = true;
+        $pipeline->save();
+
+        $resolver = app(PipelineScopeResolverService::class);
+
+        // Pipeline belongs to company 1; querying it under company 2 (stale or
+        // cross-tenant pairing) must not honor "hide all" — it should fall
+        // through to normal resolution instead of silently hiding categories.
+        $this->assertFalse($resolver->pipelineHidesAllCategories($pipeline->id, 2));
+        $this->assertNull($resolver->resolveCategoryIds($pipeline->id, $stages[0]->id, 2));
+        $this->assertNull($resolver->resolveAllCategoryIds($pipeline->id, 2));
+
+        // Same pipeline, correct company: "hide all" still applies.
+        $this->assertSame([], $resolver->resolveCategoryIds($pipeline->id, $stages[0]->id, 1));
     }
 }

--- a/tests/Unit/Services/PipelineScopeResolverServiceTest.php
+++ b/tests/Unit/Services/PipelineScopeResolverServiceTest.php
@@ -31,11 +31,13 @@ class PipelineScopeResolverServiceTest extends TestCase
 
         Schema::create('lead_pipelines', function (Blueprint $table) {
             $table->id();
+            $table->unsignedInteger('company_id')->nullable();
             $table->string('name')->nullable();
             $table->string('slug')->nullable();
             $table->integer('priority')->default(0);
             $table->string('label_color')->nullable();
             $table->integer('default')->default(0);
+            $table->boolean('hide_all_categories')->default(false);
             $table->timestamps();
         });
 
@@ -176,5 +178,36 @@ class PipelineScopeResolverServiceTest extends TestCase
 
         sort($result);
         $this->assertSame([10, 20], $result);
+    }
+
+    public function test_hide_all_categories_wins_outright_over_configured_scopes(): void
+    {
+        [$pipeline, $stages] = $this->makePipelineWithStages(2);
+
+        CustomFieldCategoryScope::create([
+            'company_id' => 1,
+            'category_id' => 100,
+            'pipeline_id' => $pipeline->id,
+            'pipeline_stage_id' => null, // pipeline-wide
+        ]);
+
+        CustomFieldCategoryScope::create([
+            'company_id' => 1,
+            'category_id' => 200,
+            'pipeline_id' => $pipeline->id,
+            'pipeline_stage_id' => $stages[0]->id,
+        ]);
+
+        $pipeline->company_id = 1;
+        $pipeline->hide_all_categories = true;
+        $pipeline->save();
+
+        $resolver = app(PipelineScopeResolverService::class);
+
+        // Even with real scopes configured, "hide all" overrides them entirely.
+        $this->assertSame([], $resolver->resolveCategoryIds($pipeline->id, $stages[0]->id, 1));
+        $this->assertSame([], $resolver->resolveAllCategoryIds($pipeline->id, 1));
+        $this->assertTrue($resolver->pipelineHidesAllCategories($pipeline->id));
+        $this->assertSame([$pipeline->id], $resolver->getHideAllCategoriesPipelineIds(1));
     }
 }


### PR DESCRIPTION
- Introduced a new boolean field 'hide_all_categories' in the LeadPipeline model to control visibility of custom field categories.
- Updated the LeadPipelineSettingController to handle the new field in pipeline settings.
- Enhanced the UpdateLeadPipeline request validation to include the new field.
- Implemented logic in the PipelineScopeResolverService to respect the 'hide_all_categories' setting when resolving category scopes.
- Updated frontend components to utilize the new feature, ensuring proper handling of category visibility based on pipeline settings.
- Added relevant translations and UI elements in the edit pipeline modal for user interaction.