### PR TITLE
fix: remove redundant get() call in SendAutoFollowUpReminder command

### DIFF
--- a/app/Console/Commands/SendAutoFollowUpReminder.php
+++ b/app/Console/Commands/SendAutoFollowUpReminder.php
@@ -82,8 +82,6 @@ class SendAutoFollowUpReminder extends Command
                     ->orWhere('send_reminder', '');
             })
             ->get();
-            })
-            ->get();
 
         foreach ($followups as $followup) {
             $recipientIds = collect($followup->participants ?? []);


### PR DESCRIPTION
- Eliminated unnecessary get() method call after query building, streamlining the retrieval of follow-up reminders.