### PR TITLE
feat: Add webinar ID support to qualification script settings and map…

### DIFF
--- a/app/Http/Controllers/QualificationFieldMappingController.php
+++ b/app/Http/Controllers/QualificationFieldMappingController.php
@@ -82,7 +82,7 @@ class QualificationFieldMappingController extends AccountBaseController
         $validated = $request->validate([
             'template_name' => ['nullable', 'string', 'max:255'],
             'auto_write' => ['required', 'boolean'],
-            'webinar_id' => ['nullable', 'string', 'max:191'],
+            'webinar_id' => ['nullable', 'string', 'max:255'],
             'mappings' => ['present', 'array'],
             'mappings.*.segment_key' => ['required', 'string', 'max:191'],
             'mappings.*.lead_field' => ['nullable', 'string', Rule::in($allowedFields)],

--- a/app/Http/Controllers/QualificationFieldMappingController.php
+++ b/app/Http/Controllers/QualificationFieldMappingController.php
@@ -59,6 +59,7 @@ class QualificationFieldMappingController extends AccountBaseController
         return Reply::dataOnly([
             'template_id' => $templateId,
             'auto_write' => $setting?->auto_write ?? true,
+            'webinar_id' => $setting?->webinar_id,
             'mappings' => $setting
                 ? $setting->mappings->map(fn (QualificationFieldMapping $mapping) => [
                     'segment_key' => $mapping->segment_key,
@@ -81,6 +82,7 @@ class QualificationFieldMappingController extends AccountBaseController
         $validated = $request->validate([
             'template_name' => ['nullable', 'string', 'max:255'],
             'auto_write' => ['required', 'boolean'],
+            'webinar_id' => ['nullable', 'string', 'max:191'],
             'mappings' => ['present', 'array'],
             'mappings.*.segment_key' => ['required', 'string', 'max:191'],
             'mappings.*.lead_field' => ['nullable', 'string', Rule::in($allowedFields)],
@@ -95,6 +97,7 @@ class QualificationFieldMappingController extends AccountBaseController
                 [
                     'template_name' => $validated['template_name'] ?? null,
                     'auto_write' => $validated['auto_write'],
+                    'webinar_id' => filled($validated['webinar_id'] ?? null) ? trim($validated['webinar_id']) : null,
                 ]
             );
 

--- a/app/Models/QualificationScriptSetting.php
+++ b/app/Models/QualificationScriptSetting.php
@@ -18,6 +18,7 @@ class QualificationScriptSetting extends BaseModel
         'template_id',
         'template_name',
         'auto_write',
+        'webinar_id',
     ];
 
     protected $casts = [

--- a/database/migrations/2026_08_13_000001_add_webinar_id_to_qualification_script_settings.php
+++ b/database/migrations/2026_08_13_000001_add_webinar_id_to_qualification_script_settings.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('qualification_script_settings')) {
+            return;
+        }
+
+        if (Schema::hasColumn('qualification_script_settings', 'webinar_id')) {
+            return;
+        }
+
+        Schema::table('qualification_script_settings', function (Blueprint $table) {
+            // OL webinar used by the inviteWebinar outcome when the script segment
+            // carries no webinarId of its own.
+            $table->string('webinar_id', 191)->nullable()->after('auto_write');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('qualification_script_settings', 'webinar_id')) {
+            return;
+        }
+
+        Schema::table('qualification_script_settings', function (Blueprint $table) {
+            $table->dropColumn('webinar_id');
+        });
+    }
+};

--- a/database/migrations/2026_08_13_000001_add_webinar_id_to_qualification_script_settings.php
+++ b/database/migrations/2026_08_13_000001_add_webinar_id_to_qualification_script_settings.php
@@ -19,7 +19,9 @@ return new class extends Migration
         Schema::table('qualification_script_settings', function (Blueprint $table) {
             // OL webinar used by the inviteWebinar outcome when the script segment
             // carries no webinarId of its own.
-            $table->string('webinar_id', 191)->nullable()->after('auto_write');
+            // Explicit length: the app's global defaultStringLength is 191, and OL
+            // ids are opaque. Not indexed, so the utf8mb4 key limit doesn't apply.
+            $table->string('webinar_id', 255)->nullable()->after('auto_write');
         });
     }
 

--- a/resources/js/Features/Leads/QualificationMapping/mappingApi.ts
+++ b/resources/js/Features/Leads/QualificationMapping/mappingApi.ts
@@ -16,6 +16,8 @@ export interface FieldMappingRow {
 export interface ScriptMapping {
     template_id: string;
     auto_write: boolean;
+    /** OL webinar used by the inviteWebinar outcome when the script carries none. */
+    webinar_id: string | null;
     mappings: FieldMappingRow[];
 }
 
@@ -32,6 +34,7 @@ const normalize = (raw: unknown, templateId: string): ScriptMapping => {
     return {
         template_id: templateId,
         auto_write: data.auto_write !== false,
+        webinar_id: data.webinar_id || null,
         mappings: (data.mappings ?? []).map((row) => ({
             segment_key: row.segment_key,
             lead_field: row.lead_field ?? null,

--- a/resources/js/Pages/Leads/QualificationMapping/Index.tsx
+++ b/resources/js/Pages/Leads/QualificationMapping/Index.tsx
@@ -219,7 +219,9 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
         JSON.stringify(draft) !== JSON.stringify(saved.draft);
 
     const handleSave = async () => {
-        if (!templateId || saving) return;
+        // Saving mid-load would post an empty question list and wipe the
+        // mapping rows that haven't arrived yet.
+        if (!templateId || saving || loading) return;
         setSaving(true);
         try {
             const mappings = questions.map((segment) => rowFor(segment.key));
@@ -318,7 +320,7 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
                             variant="primary"
                             icon={<Icon name="check" size={13} />}
                             loading={saving}
-                            disabled={!templateId || !dirty}
+                            disabled={!templateId || !dirty || loading}
                             onClick={() => void handleSave()}
                         >
                             {td("Save mapping", { source: "en" })}
@@ -403,6 +405,7 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
                         placeholder={td("e.g. test-updated-webinar", {
                             source: "en",
                         })}
+                        maxLength={255}
                         disabled={!templateId || loading}
                         style={{
                             ...SELECT_TRIGGER,

--- a/resources/js/Pages/Leads/QualificationMapping/Index.tsx
+++ b/resources/js/Pages/Leads/QualificationMapping/Index.tsx
@@ -81,9 +81,15 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
     const [saving, setSaving] = useState(false);
 
     const [autoWrite, setAutoWrite] = useState(true);
+    const [webinarId, setWebinarId] = useState("");
     const [draft, setDraft] = useState<Draft>({});
-    const [saved, setSaved] = useState<{ autoWrite: boolean; draft: Draft }>({
+    const [saved, setSaved] = useState<{
+        autoWrite: boolean;
+        webinarId: string;
+        draft: Draft;
+    }>({
         autoWrite: true,
+        webinarId: "",
         draft: {},
     });
     const [optionsFor, setOptionsFor] = useState<Segment | null>(null);
@@ -132,7 +138,12 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
                 }
                 setDraft(next);
                 setAutoWrite(mapping.auto_write);
-                setSaved({ autoWrite: mapping.auto_write, draft: next });
+                setWebinarId(mapping.webinar_id ?? "");
+                setSaved({
+                    autoWrite: mapping.auto_write,
+                    webinarId: mapping.webinar_id ?? "",
+                    draft: next,
+                });
             })
             .catch(() => {
                 if (!cancelled) message.error("Failed to load the script mapping");
@@ -204,6 +215,7 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
 
     const dirty =
         autoWrite !== saved.autoWrite ||
+        webinarId.trim() !== saved.webinarId ||
         JSON.stringify(draft) !== JSON.stringify(saved.draft);
 
     const handleSave = async () => {
@@ -211,9 +223,11 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
         setSaving(true);
         try {
             const mappings = questions.map((segment) => rowFor(segment.key));
+            const trimmedWebinarId = webinarId.trim();
             await saveScriptMapping(templateId, {
                 template_name: template?.name ?? null,
                 auto_write: autoWrite,
+                webinar_id: trimmedWebinarId || null,
                 mappings,
             });
             const next: Draft = {};
@@ -221,7 +235,8 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
                 if (row.lead_field) next[row.segment_key] = row;
             }
             setDraft(next);
-            setSaved({ autoWrite, draft: next });
+            setWebinarId(trimmedWebinarId);
+            setSaved({ autoWrite, webinarId: trimmedWebinarId, draft: next });
             message.success(td("Mapping saved", { source: "en" }));
         } catch {
             message.error(td("Failed to save the mapping", { source: "en" }));
@@ -233,6 +248,7 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
     const handleDiscard = () => {
         setDraft(saved.draft);
         setAutoWrite(saved.autoWrite);
+        setWebinarId(saved.webinarId);
     };
 
     return (
@@ -354,6 +370,49 @@ const QualificationMappingIndex = ({ leadFields, writeModes }: Props) => {
                                 : td("questions need options", { source: "en" })}
                         </Badge>
                     ) : null}
+                </div>
+
+                <div
+                    className="flex items-center gap-3.5 rounded-xl flex-wrap"
+                    style={{
+                        background: T.SURFACE,
+                        border: `1px solid ${T.BORDER}`,
+                        padding: "14px 18px",
+                    }}
+                >
+                    <div className="min-w-0 flex-1">
+                        <div
+                            className="text-[14px] font-semibold"
+                            style={{ color: T.TEXT }}
+                        >
+                            {td("Webinar for this script", { source: "en" })}
+                        </div>
+                        <div
+                            className="text-[12px]"
+                            style={{ color: T.TEXT_MUTED }}
+                        >
+                            {td(
+                                "OL webinar id used when the agent picks the webinar invite outcome. Leave empty if the script already carries its own webinar.",
+                                { source: "en" },
+                            )}
+                        </div>
+                    </div>
+                    <input
+                        value={webinarId}
+                        onChange={(event) => setWebinarId(event.target.value)}
+                        placeholder={td("e.g. test-updated-webinar", {
+                            source: "en",
+                        })}
+                        disabled={!templateId || loading}
+                        style={{
+                            ...SELECT_TRIGGER,
+                            width: 260,
+                            borderRadius: 8,
+                            border: `1px solid ${T.BORDER}`,
+                            color: T.TEXT,
+                            background: "#fff",
+                        }}
+                    />
                 </div>
 
                 <div

--- a/resources/js/Pages/Leads/Redesign/LeadViewRedesign.tsx
+++ b/resources/js/Pages/Leads/Redesign/LeadViewRedesign.tsx
@@ -554,9 +554,6 @@ function LeadViewRedesignInner(props: LeadRedesignProps) {
                             return ok;
                         }}
                         onStartQualify={openTemplatePicker}
-                        onStartWithScript={(templateId) => {
-                            void handleTemplateSelect(templateId);
-                        }}
                     />
                 ) : (
                     <p style={{ margin: 0, color: "#9ca3af", fontSize: 13 }}>

--- a/resources/js/Pages/Leads/Redesign/components/qualification/QualifyOutcomePhase.tsx
+++ b/resources/js/Pages/Leads/Redesign/components/qualification/QualifyOutcomePhase.tsx
@@ -49,6 +49,7 @@ import useLeadMeetingCreate, {
     type LeadMeetingCreateInput,
 } from "../../hooks/useLeadMeetingCreate";
 import useLeadFieldUpdate from "../../hooks/useLeadFieldUpdate";
+import { useScriptMapping } from "@/Features/Leads/QualificationMapping/mappingApi";
 import { Empty, Spin, message } from "antd";
 import { useEffect, useMemo, useState } from "react";
 
@@ -721,7 +722,15 @@ function OutcomeDetail({
         };
     }, [lead.marketing]);
 
-    const webinarId = treeSegment?.outcomeMetadata?.webinarId;
+    // Falls back to the webinar an admin set for this script on the
+    // qualification field mapping settings page.
+    const scriptMapping = useScriptMapping(
+        outcome === "inviteWebinar" ? flow.templateTree?.templateId : null,
+    );
+    const webinarId =
+        treeSegment?.outcomeMetadata?.webinarId ||
+        scriptMapping?.webinar_id ||
+        undefined;
 
     /** `/sessions/next` yields a single upcoming session. */
     const nextSession = webinarSessions[0] ?? null;

--- a/resources/js/Pages/Leads/Redesign/components/workspace/tabs/QualificationTab.tsx
+++ b/resources/js/Pages/Leads/Redesign/components/workspace/tabs/QualificationTab.tsx
@@ -36,8 +36,6 @@ interface QualificationTabProps {
     current: LeadQualification | null;
     history: LeadQualification[];
     onStartQualify?: () => void;
-    /** Repeat a script the lead has already been called with. */
-    onStartWithScript?: (templateId: string) => void;
     onResumeQualify?: (qualification: LeadQualification) => void;
     onDeleteQualify?: (qualification: LeadQualification) => Promise<boolean> | boolean;
     canStart?: boolean;
@@ -143,7 +141,6 @@ export default function QualificationTab({
     current,
     history,
     onStartQualify,
-    onStartWithScript,
     onResumeQualify,
     onDeleteQualify,
     canStart,
@@ -258,8 +255,9 @@ export default function QualificationTab({
                                 : td("scripts", { source: "en" })}
                         </span>
                     </div>
-                    {/* Always present — an open call disables them rather than
-                        hiding them, so the rail header never loses its actions. */}
+                    {/* Always present — an open call disables it rather than
+                        hiding it, so the rail header never loses its action.
+                        Picks the script (auto-starts when there's only one). */}
                     <div className="flex flex-col gap-2 mt-3">
                         <Button
                             size="sm"
@@ -275,33 +273,9 @@ export default function QualificationTab({
                                           { source: "en" },
                                       )
                             }
-                            onClick={() => {
-                                const lastScript = calls[0]?.template_id;
-                                if (lastScript && onStartWithScript) {
-                                    onStartWithScript(lastScript);
-                                } else {
-                                    onStartQualify?.();
-                                }
-                            }}
-                        >
-                            {td("New qualification call", { source: "en" })}
-                        </Button>
-                        <Button
-                            size="sm"
-                            icon={<Icon name="layers" size={13} />}
-                            style={{ width: "100%" }}
-                            disabled={!canStart}
-                            title={
-                                canStart
-                                    ? undefined
-                                    : td(
-                                          "Finish the open call before starting another.",
-                                          { source: "en" },
-                                      )
-                            }
                             onClick={onStartQualify}
                         >
-                            {td("Call with another script", { source: "en" })}
+                            {td("New qualification call", { source: "en" })}
                         </Button>
                     </div>
                     {hasInProgress ? (

--- a/tests/LeadQualificationTestCase.php
+++ b/tests/LeadQualificationTestCase.php
@@ -153,6 +153,7 @@ abstract class LeadQualificationTestCase extends TestCase
             $table->string('template_id');
             $table->string('template_name')->nullable();
             $table->boolean('auto_write')->default(true);
+            $table->string('webinar_id')->nullable();
             $table->timestamps();
         });
 

--- a/tests/LeadQualificationTestCase.php
+++ b/tests/LeadQualificationTestCase.php
@@ -153,7 +153,7 @@ abstract class LeadQualificationTestCase extends TestCase
             $table->string('template_id');
             $table->string('template_name')->nullable();
             $table->boolean('auto_write')->default(true);
-            $table->string('webinar_id')->nullable();
+            $table->string('webinar_id', 255)->nullable();
             $table->timestamps();
         });
 


### PR DESCRIPTION
…ping

- Introduced a new `webinar_id` field in the QualificationScriptSetting model and updated the corresponding migration to include this field in the database.
- Enhanced the QualificationFieldMappingController to handle the `webinar_id` in both data retrieval and validation processes.
- Updated frontend components to manage and display the `webinar_id`, including input handling in the QualificationMappingIndex and integration with the script mapping logic.
- Ensured that the new field is properly reflected in the API and UI, improving the lead qualification process.