### PR TITLE
refactor: Remove feature flag checks for core fields in LeadCoreFieldsService and related components

### DIFF
--- a/app/Http/Controllers/Api/DealContactApiController.php
+++ b/app/Http/Controllers/Api/DealContactApiController.php
@@ -547,7 +547,7 @@ class DealContactApiController extends Controller
             $corePayload['occupation'] = $request->input('occupation');
         }
 
-        if ($corePayload !== [] && $coreFieldsService->useCoreFields()) {
+        if ($corePayload !== []) {
             $before = $coreFieldsService->read($lead);
             $coreFieldsService->write($lead, $corePayload);
             $after = $coreFieldsService->read($lead);

--- a/app/Services/DealGatheringService.php
+++ b/app/Services/DealGatheringService.php
@@ -434,12 +434,8 @@ class DealGatheringService
                     if (! empty($promotedData)) {
                         /** @var \App\Services\LeadCoreFieldsService $coreFields */
                         $coreFields = app(\App\Services\LeadCoreFieldsService::class);
-                        if ($coreFields->useCoreFields()) {
-                            $coreFields->write($deal->contact, $promotedData);
-                            $deal->contact->save();
-                        } else {
-                            $deal->contact->update($promotedData);
-                        }
+                        $coreFields->write($deal->contact, $promotedData);
+                        $deal->contact->save();
                     }
                 }
                 break;

--- a/app/Services/LeadCoreFieldsService.php
+++ b/app/Services/LeadCoreFieldsService.php
@@ -6,11 +6,8 @@ use App\Models\CustomField;
 use App\Models\LanguageSetting;
 use App\Models\Lead;
 use App\Enums\AgeRange;
-use App\Support\FeatureFlags;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 
 class LeadCoreFieldsService
@@ -26,35 +23,22 @@ class LeadCoreFieldsService
     /** @var array<int, array<string, int>> */
     private array $slugToIdCache = [];
 
-    public function useCoreFields(): bool
-    {
-        return FeatureFlags::enabled('crm.lead-language-core-field');
-    }
-
     public function read(Lead $lead): array
     {
-        if ($this->useCoreFields()) {
-            return [
-                'languages' => $lead->languages ?? [],
-                'date_of_birth' => $lead->date_of_birth?->format('Y-m-d'),
-                'age' => $lead->age,
-                'age_range' => $lead->age_range instanceof AgeRange
-                    ? $lead->age_range->value
-                    : $lead->age_range,
-                'nationality' => $lead->nationality,
-                'occupation' => $lead->occupation,
-            ];
-        }
-
-        return $this->readFromCustomFields($lead);
+        return [
+            'languages' => $lead->languages ?? [],
+            'date_of_birth' => $lead->date_of_birth?->format('Y-m-d'),
+            'age' => $lead->age,
+            'age_range' => $lead->age_range instanceof AgeRange
+                ? $lead->age_range->value
+                : $lead->age_range,
+            'nationality' => $lead->nationality,
+            'occupation' => $lead->occupation,
+        ];
     }
 
     public function write(Lead $lead, array $data): void
     {
-        if (!$this->useCoreFields()) {
-            return;
-        }
-
         if (array_key_exists('languages', $data)) {
             $lead->languages = $this->normalizeLanguages($data['languages']);
         }
@@ -104,10 +88,6 @@ class LeadCoreFieldsService
      */
     public function filterCustomFieldsFromPayload(array $payload, int $companyId): array
     {
-        if (!$this->useCoreFields()) {
-            return $payload;
-        }
-
         $promotedIds = array_values($this->slugToIdMap($companyId));
 
         foreach (['custom_fields_data', 'custom_fields'] as $key) {
@@ -132,13 +112,7 @@ class LeadCoreFieldsService
      */
     public function filterPromotedFieldDefinitions(iterable $fields): Collection
     {
-        $collection = collect($fields);
-
-        if (!$this->useCoreFields()) {
-            return $collection->values();
-        }
-
-        return $collection
+        return collect($fields)
             ->filter(function ($field) {
                 $name = is_array($field) ? ($field['name'] ?? null) : ($field->name ?? null);
 
@@ -158,10 +132,6 @@ class LeadCoreFieldsService
 
     public function validationRules(bool $sometimes = false): array
     {
-        if (!$this->useCoreFields()) {
-            return [];
-        }
-
         $languageCodes = LanguageSetting::pluck('language_code')->filter()->implode(',');
         $sometimesRules = $sometimes ? ['sometimes'] : [];
         $languageItemRule = $languageCodes !== ''
@@ -177,64 +147,6 @@ class LeadCoreFieldsService
             'nationality' => [...$sometimesRules, 'nullable', 'string', 'max:255'],
             'occupation' => [...$sometimesRules, 'nullable', 'string', 'max:255'],
         ];
-    }
-
-    private function readFromCustomFields(Lead $lead): array
-    {
-        $companyId = (int) ($lead->company_id ?? company()?->id);
-        $slugMap = $this->slugToIdMap($companyId);
-
-        $rawLanguage = $this->customFieldValueForLead($lead, $slugMap['language'] ?? null);
-        $languages = $rawLanguage !== null
-            ? $this->normalizeLanguages($rawLanguage)
-            : [];
-
-        $dateOfBirth = null;
-        $rawDob = $this->customFieldValueForLead($lead, $slugMap['date-of-birth'] ?? null);
-        if ($rawDob) {
-            try {
-                $dateOfBirth = Carbon::parse($rawDob)->format('Y-m-d');
-            } catch (\Throwable $e) {
-                Log::warning('Lead core field read: unparseable date_of_birth from custom field', [
-                    'lead_id' => $lead->id,
-                    'value' => $rawDob,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-
-        $nationality = $this->customFieldValueForLead($lead, $slugMap['nationality'] ?? null);
-        $occupation = $this->customFieldValueForLead($lead, $slugMap['occupation'] ?? null);
-        $rawAgeRange = $this->customFieldValueForLead($lead, $slugMap['age'] ?? null);
-        $ageRange = null;
-
-        if ($rawAgeRange) {
-            $ageRange = AgeRange::tryFrom($rawAgeRange)?->value ?? $rawAgeRange;
-        }
-
-        return [
-            'languages' => $languages,
-            'date_of_birth' => $dateOfBirth,
-            'age' => null,
-            'age_range' => $ageRange,
-            'nationality' => $nationality ?: null,
-            'occupation' => $occupation ?: null,
-        ];
-    }
-
-    private function customFieldValueForLead(Lead $lead, ?int $fieldId): ?string
-    {
-        if ($fieldId === null || !$lead->id) {
-            return null;
-        }
-
-        $value = DB::table('custom_fields_data')
-            ->where('custom_field_id', $fieldId)
-            ->where('model', Lead::CUSTOM_FIELD_MODEL)
-            ->where('model_id', $lead->id)
-            ->value('value');
-
-        return $value !== null ? (string) $value : null;
     }
 
     /**

--- a/app/Services/LeadService.php
+++ b/app/Services/LeadService.php
@@ -37,7 +37,6 @@ class LeadService
         'qualification_segment_key',
         'qualification_answer_values',
         'language',
-        'language_id',
         'temperature',
         'preferred_contact_time',
         'gender',
@@ -586,7 +585,7 @@ class LeadService
             $this->applyNextActionFilter($query, $request->get('next_action'));
         }
 
-        if ($this->coreFieldsService->useCoreFields() && $request->filled('language')) {
+        if ($request->filled('language')) {
             $languageCodes = $this->toValueArray($request->get('language'));
             $query->where(function ($q) use ($languageCodes) {
                 foreach ($languageCodes as $code) {

--- a/config/features.php
+++ b/config/features.php
@@ -5,7 +5,6 @@ return [
     'cache_ttl' => (int) env('FEATURE_FLAGS_CACHE_TTL', 10),
     'known_flags' => [
         'crm.lead-qualification-tab',
-        'crm.lead-language-core-field',
         'crm.deal-view-redesign',
         'crm.lead-view-redesign',
         'crm.lead-ai-summary',

--- a/resources/js/Features/Leads/SaveLead/BasicInfoTab.tsx
+++ b/resources/js/Features/Leads/SaveLead/BasicInfoTab.tsx
@@ -89,7 +89,6 @@ const BasicInfoTab: React.FC<BasicInfoTabProps> = ({
         categories,
         employees,
         permissions,
-        featureFlags,
         leadLifecycleStatuses,
     } = props;
     const lifecycleStatusOptions = useMemo(
@@ -105,8 +104,6 @@ const BasicInfoTab: React.FC<BasicInfoTabProps> = ({
             })),
         [leadLifecycleStatuses],
     );
-    const useLeadCoreFields =
-        featureFlags?.["crm.lead-language-core-field"] === true;
     const [form] = Form.useForm();
     const isPopulatingRef = useRef(false);
     const defaultCurrencySymbol = props.default_currency_symbol || "£";
@@ -405,8 +402,7 @@ const BasicInfoTab: React.FC<BasicInfoTabProps> = ({
                     {createDeal && <LeadDealCreation />}
                 </section>
 
-                {useLeadCoreFields && (
-                    <section className="save-lead-form__section">
+                <section className="save-lead-form__section">
                         <h3 className="save-lead-form__section-title">
                             Personal information
                         </h3>
@@ -495,8 +491,7 @@ const BasicInfoTab: React.FC<BasicInfoTabProps> = ({
                                 </Form.Item>
                             </Col>
                         </Row>
-                    </section>
-                )}
+                </section>
 
                 <section className="save-lead-form__section">
                     <h3 className="save-lead-form__section-title">

--- a/resources/js/Pages/Leads/Components/LeadInfoSection.tsx
+++ b/resources/js/Pages/Leads/Components/LeadInfoSection.tsx
@@ -72,7 +72,6 @@ interface Props {
     projects: any[];
     isEditMode: boolean;
     onEditModeChange: (value: boolean) => void;
-    useLeadCoreFields?: boolean;
 }
 
 export default function LeadInfoSection({
@@ -88,7 +87,6 @@ export default function LeadInfoSection({
     projects,
     isEditMode,
     onEditModeChange,
-    useLeadCoreFields = false,
 }: Props) {
     const { props } = usePage();
     const languageOptions = (
@@ -1098,9 +1096,7 @@ const ageRangeOptions = useMemo(
                             />
                         </DetailField>
 
-                        {useLeadCoreFields && (
-                            <>
-                                <DetailField label={t("pages.leads.info.fields.languages", { defaultValue: "Languages" })}>
+                        <DetailField label={t("pages.leads.info.fields.languages", { defaultValue: "Languages" })}>
                                     <EditableField
                                         value={currentLeadState.languages || []}
                                         fieldName="languages"
@@ -1208,8 +1204,6 @@ const ageRangeOptions = useMemo(
                                         loading={isFieldLoading("occupation")}
                                     />
                                 </DetailField>
-                            </>
-                        )}
 
                         <DetailField label={t("pages.leads.info.fields.company")}>
                             <EditableField

--- a/resources/js/Pages/Leads/Index.tsx
+++ b/resources/js/Pages/Leads/Index.tsx
@@ -92,8 +92,6 @@ const Index = ({
     const { t } = useTranslation();
     const { td } = useTd();
     const { props: pageProps } = usePage<PageProps>();
-    const useLeadCoreFields =
-        pageProps.featureFlags?.["crm.lead-language-core-field"] === true;
     // Redesigned two-pane filter workbench + saved views (mockups 1a/2a/2b/3c).
     const useFilterV2 =
         pageProps.featureFlags?.["crm.leads-filter-v2"] === true;
@@ -155,11 +153,10 @@ const Index = ({
                     leadLifecycleStatuses.length > 0
                         ? leadLifecycleStatuses
                         : formData["lead-lifecycle-statuses"] || [],
-                useLeadCoreFields,
                 filterV2: useFilterV2,
                 excludeFields: ["search"],
             }),
-        [formData, leadLifecycleStatuses, preferredContactTimes, useLeadCoreFields, useFilterV2],
+        [formData, leadLifecycleStatuses, preferredContactTimes, useFilterV2],
     );
 
     // Setup search and filter contexts

--- a/resources/js/Pages/Leads/LegacyLeadShow.tsx
+++ b/resources/js/Pages/Leads/LegacyLeadShow.tsx
@@ -56,8 +56,6 @@ export default function LegacyLeadShow({
     const taskPerms = permissions ?? taskPermissions ?? {};
     const showQualificationTab =
         featureFlags?.["crm.lead-qualification-tab"] === true;
-    const useLeadCoreFields =
-        featureFlags?.["crm.lead-language-core-field"] === true;
     const showAiSummary = featureFlags?.["crm.lead-ai-summary"] === true;
 
     const [activeTab, setActiveTab] = useState(
@@ -124,7 +122,6 @@ export default function LegacyLeadShow({
                     projects={projects}
                     isEditMode={isEditMode}
                     onEditModeChange={setIsEditMode}
-                    useLeadCoreFields={useLeadCoreFields}
                 />
             ),
         },

--- a/resources/js/configs/leadFilterConfig.ts
+++ b/resources/js/configs/leadFilterConfig.ts
@@ -270,37 +270,19 @@ export const createLeadFilterConfig = (props: any): FilterConfig => ({
                     label: country.nicename,
                 })) || [],
         },
-        ...(props.useLeadCoreFields
-            ? [
-                  {
-                      key: "language",
-                      label: "Languages",
-                      type: "multiselect" as const,
-                      control: "pills" as const,
-                      sentence: "language",
-                      section: "Profile",
-                      options:
-                          props.languages?.map((language: any) => ({
-                              value: language.language_code,
-                              label: language.language_name,
-                          })) || [],
-                  },
-              ]
-            : [
-                  {
-                      key: "language_id",
-                      label: "Languages",
-                      type: "multiselect" as const,
-                      control: "pills" as const,
-                      sentence: "language",
-                      section: "Profile",
-                      options:
-                          props.languages?.map((language: any) => ({
-                              value: language.id,
-                              label: language.language_name,
-                          })) || [],
-                  },
-              ]),
+        {
+            key: "language",
+            label: "Languages",
+            type: "multiselect",
+            control: "pills",
+            sentence: "language",
+            section: "Profile",
+            options:
+                props.languages?.map((language: any) => ({
+                    value: language.language_code,
+                    label: language.language_name,
+                })) || [],
+        },
 
         // ── Engagement ───────────────────────────────────────────
         {

--- a/tests/Feature/LeadCoreFieldPromotions/LeadCoreFieldsServiceTest.php
+++ b/tests/Feature/LeadCoreFieldPromotions/LeadCoreFieldsServiceTest.php
@@ -6,13 +6,10 @@ use App\Models\Lead;
 use App\Services\LeadCoreFieldsService;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use Tests\Concerns\SetsFeatureFlags;
 use Tests\LeadCoreFieldsTestCase;
 
 class LeadCoreFieldsServiceTest extends LeadCoreFieldsTestCase
 {
-    use SetsFeatureFlags;
-
     private LeadCoreFieldsService $service;
 
     protected function setUp(): void
@@ -30,25 +27,8 @@ class LeadCoreFieldsServiceTest extends LeadCoreFieldsTestCase
         parent::tearDown();
     }
 
-    public function test_flag_off_reads_from_custom_fields(): void
+    public function test_reads_from_core_columns(): void
     {
-        $this->setFeatureFlag('crm.lead-language-core-field', false);
-
-        $companyId = $this->seedCompany();
-        $leadId = $this->seedLead($companyId);
-        $languageFieldId = $this->seedCustomField($companyId, 'language');
-        $this->seedCustomFieldValue($languageFieldId, $leadId, 'German');
-
-        $lead = Lead::withoutGlobalScopes()->findOrFail($leadId);
-        $values = $this->service->read($lead);
-
-        $this->assertSame(['de'], $values['languages']);
-    }
-
-    public function test_flag_on_reads_from_core_columns(): void
-    {
-        $this->setFeatureFlag('crm.lead-language-core-field', true);
-
         $companyId = $this->seedCompany();
         $leadId = $this->seedLead($companyId, [
             'languages' => json_encode(['en', 'de']),
@@ -66,10 +46,8 @@ class LeadCoreFieldsServiceTest extends LeadCoreFieldsTestCase
         $this->assertSame('Engineer', $values['occupation']);
     }
 
-    public function test_flag_on_writes_core_columns_only(): void
+    public function test_writes_core_columns(): void
     {
-        $this->setFeatureFlag('crm.lead-language-core-field', true);
-
         $companyId = $this->seedCompany();
         $leadId = $this->seedLead($companyId);
         $lead = Lead::withoutGlobalScopes()->findOrFail($leadId);
@@ -89,29 +67,8 @@ class LeadCoreFieldsServiceTest extends LeadCoreFieldsTestCase
         $this->assertSame('1985-01-20', $lead->date_of_birth?->format('Y-m-d'));
     }
 
-    public function test_flag_off_write_is_noop(): void
+    public function test_filter_custom_fields_from_payload(): void
     {
-        $this->setFeatureFlag('crm.lead-language-core-field', false);
-
-        $companyId = $this->seedCompany();
-        $leadId = $this->seedLead($companyId);
-        $lead = Lead::withoutGlobalScopes()->findOrFail($leadId);
-
-        $this->service->write($lead, [
-            'languages' => ['en'],
-            'nationality' => 'Turkey',
-        ]);
-        $lead->save();
-        $lead->refresh();
-
-        $this->assertNull($lead->languages);
-        $this->assertNull($lead->nationality);
-    }
-
-    public function test_filter_custom_fields_from_payload_when_flag_on(): void
-    {
-        $this->setFeatureFlag('crm.lead-language-core-field', true);
-
         $companyId = $this->seedCompany();
         $languageFieldId = $this->seedCustomField($companyId, 'language');
         $otherFieldId = $this->seedCustomField($companyId, 'custom-note');
@@ -238,13 +195,4 @@ class LeadCoreFieldsServiceTest extends LeadCoreFieldsTestCase
         ]);
     }
 
-    private function seedCustomFieldValue(int $fieldId, int $leadId, string $value): void
-    {
-        \DB::table('custom_fields_data')->insert([
-            'custom_field_id' => $fieldId,
-            'model_id' => $leadId,
-            'model' => 'App\Models\Lead',
-            'value' => $value,
-        ]);
-    }
 }

--- a/tests/Unit/FeatureFlagServiceTest.php
+++ b/tests/Unit/FeatureFlagServiceTest.php
@@ -24,7 +24,7 @@ class FeatureFlagServiceTest extends TestCase
                 'success' => true,
                 'data' => [
                     'flags' => [
-                        'crm.lead-language-core-field' => true,
+                        'crm.lead-qualification-tab' => true,
                         'sales.per-agent-commission-override' => false,
                     ],
                 ],
@@ -33,13 +33,13 @@ class FeatureFlagServiceTest extends TestCase
 
         $service = app(FeatureFlagService::class);
 
-        $this->assertTrue($service->isEnabled('crm.lead-language-core-field'));
+        $this->assertTrue($service->isEnabled('crm.lead-qualification-tab'));
         $this->assertFalse($service->isEnabled('sales.per-agent-commission-override'));
         $this->assertSame([
-            'crm.lead-language-core-field' => true,
+            'crm.lead-qualification-tab' => true,
             'sales.per-agent-commission-override' => false,
         ], array_intersect_key($service->all(), [
-            'crm.lead-language-core-field' => true,
+            'crm.lead-qualification-tab' => true,
             'sales.per-agent-commission-override' => true,
         ]));
     }
@@ -51,7 +51,7 @@ class FeatureFlagServiceTest extends TestCase
                 'success' => true,
                 'data' => [
                     'flags' => [
-                        'crm.lead-language-core-field' => true,
+                        'crm.deal-view-redesign' => true,
                     ],
                 ],
             ]),
@@ -66,7 +66,7 @@ class FeatureFlagServiceTest extends TestCase
     public function test_api_failure_uses_stale_cache_when_available(): void
     {
         Cache::put('feature_flags:crm:system', [
-            'crm.lead-language-core-field' => true,
+            'crm.lead-qualification-tab' => true,
             'sales.per-agent-commission-override' => true,
         ], 60);
 
@@ -76,7 +76,7 @@ class FeatureFlagServiceTest extends TestCase
 
         $service = app(FeatureFlagService::class);
 
-        $this->assertTrue($service->isEnabled('crm.lead-language-core-field'));
+        $this->assertTrue($service->isEnabled('crm.lead-qualification-tab'));
         $this->assertTrue($service->isEnabled('sales.per-agent-commission-override'));
     }
 
@@ -88,7 +88,7 @@ class FeatureFlagServiceTest extends TestCase
 
         $service = app(FeatureFlagService::class);
 
-        $this->assertFalse($service->isEnabled('crm.lead-language-core-field'));
+        $this->assertFalse($service->isEnabled('crm.lead-qualification-tab'));
         $this->assertFalse($service->isEnabled('sales.per-agent-commission-override'));
         $this->assertFalse($service->forInertia()['sales.bulk-agent-promotion']);
     }
@@ -100,7 +100,7 @@ class FeatureFlagServiceTest extends TestCase
                 'success' => true,
                 'data' => [
                     'flags' => [
-                        'crm.lead-language-core-field' => true,
+                        'crm.lead-qualification-tab' => true,
                         'shell.websocket' => true,
                     ],
                 ],
@@ -110,9 +110,9 @@ class FeatureFlagServiceTest extends TestCase
         $service = app(FeatureFlagService::class);
         $inertiaFlags = $service->forInertia();
 
-        $this->assertArrayHasKey('crm.lead-language-core-field', $inertiaFlags);
+        $this->assertArrayHasKey('crm.lead-qualification-tab', $inertiaFlags);
         $this->assertArrayNotHasKey('shell.websocket', $inertiaFlags);
-        $this->assertTrue($inertiaFlags['crm.lead-language-core-field']);
+        $this->assertTrue($inertiaFlags['crm.lead-qualification-tab']);
     }
 
     public function test_deal_view_redesign_flag_is_exposed_for_inertia(): void


### PR DESCRIPTION
- Eliminated the use of the `crm.lead-language-core-field` feature flag across various services and components, simplifying the logic for reading and writing lead data.
- Updated the `LeadCoreFieldsService` to always read from core columns, removing the conditional checks for feature flags.
- Adjusted related services and frontend components to reflect the removal of feature flag dependencies, ensuring consistent behavior for lead data handling.
- Enhanced tests to validate the new behavior without feature flag checks.