### PR TITLE
refactor: Remove preserveState and preserveScroll options from router…

### DIFF
--- a/resources/js/Pages/Tasks/Redesign/TasksWorkspaceRedesign.tsx
+++ b/resources/js/Pages/Tasks/Redesign/TasksWorkspaceRedesign.tsx
@@ -410,8 +410,6 @@ export default function TasksWorkspaceRedesign({
         if (checklist.length || files.length) {
             router.reload({
                 only: ["kanbanTasks", "tableTasks", "stats"],
-                preserveState: true,
-                preserveScroll: true,
             });
         }
     };
@@ -603,8 +601,6 @@ export default function TasksWorkspaceRedesign({
                 "savedViews",
                 "taskQuickCounts",
             ],
-            preserveState: true,
-            preserveScroll: true,
             onSuccess: (page) => {
                 const props = page.props as {
                     kanbanTasks?: Task[];
@@ -1183,8 +1179,6 @@ export default function TasksWorkspaceRedesign({
                                 "taskQuickCounts",
                                 "stats",
                             ],
-                            preserveState: true,
-                            preserveScroll: true,
                         });
                     }
                 }}
@@ -1202,8 +1196,6 @@ export default function TasksWorkspaceRedesign({
                     setTaskSettingsOpen(false);
                     router.reload({
                         only: ["categories"],
-                        preserveState: true,
-                        preserveScroll: true,
                     });
                 }}
                 footer={null}


### PR DESCRIPTION
… reloads

- Eliminated `preserveState` and `preserveScroll` options from multiple router reload calls in the `TasksWorkspaceRedesign` component.
- Streamlined the reload logic to enhance performance and simplify state management during task updates.