### PR TITLE
feat: Implement meeting attendance confirmation feature

### DIFF
--- a/app/Enums/DealActivityType.php
+++ b/app/Enums/DealActivityType.php
@@ -32,6 +32,7 @@ enum DealActivityType: string
     case MEETING_SCHEDULED = 'meeting_scheduled';
     case MEETING_UPDATED = 'meeting_updated';
     case MEETING_CANCELLED = 'meeting_cancelled';
+    case MEETING_OUTCOME_LOGGED = 'meeting_outcome_logged';
 
     // Files
     case FILE_UPLOADED = 'file_uploaded';
@@ -82,6 +83,7 @@ enum DealActivityType: string
             self::MEETING_SCHEDULED => 'Meeting Scheduled',
             self::MEETING_UPDATED => 'Meeting Updated',
             self::MEETING_CANCELLED => 'Meeting Cancelled',
+            self::MEETING_OUTCOME_LOGGED => 'Meeting Outcome Logged',
             self::FILE_UPLOADED => 'File Uploaded',
             self::FILE_UPDATED => 'File Updated',
             self::FILE_DELETED => 'File Deleted',
@@ -109,7 +111,7 @@ enum DealActivityType: string
             self::NOTE_ADDED, self::NOTE_UPDATED, self::NOTE_DELETED => 'note',
             self::STAGE_CHANGED, self::PIPELINE_CHANGED, self::DEAL_WON, self::DEAL_LOST => 'stage',
             self::TASK_ADDED, self::TASK_UPDATED, self::TASK_COMPLETED, self::TASK_DELETED => 'task',
-            self::MEETING_SCHEDULED, self::MEETING_UPDATED, self::MEETING_CANCELLED => 'meeting',
+            self::MEETING_SCHEDULED, self::MEETING_UPDATED, self::MEETING_CANCELLED, self::MEETING_OUTCOME_LOGGED => 'meeting',
             self::FILE_UPLOADED, self::FILE_UPDATED, self::FILE_DELETED => 'file',
             self::PROPERTY_LINKED, self::PROPERTY_UNLINKED => 'property',
             self::PACKAGE_ASSIGNED, self::PACKAGE_REMOVED => 'package',

--- a/app/Enums/MeetingAttendanceOutcome.php
+++ b/app/Enums/MeetingAttendanceOutcome.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Enums;
+
+enum MeetingAttendanceOutcome: string
+{
+    case Attended = 'attended';
+    case NoShow = 'no_show';
+    case Rescheduled = 'rescheduled';
+    case Cancelled = 'cancelled';
+    case Partial = 'partial';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Attended => 'Attended',
+            self::NoShow => 'Did not attend (no-show)',
+            self::Rescheduled => 'Rescheduled / postponed',
+            self::Cancelled => 'Cancelled',
+            self::Partial => 'Partially attended',
+        };
+    }
+
+    public function helper(): string
+    {
+        return match ($this) {
+            self::Attended => 'Showed up as planned',
+            self::NoShow => 'Missed it without notice',
+            self::Rescheduled => 'Moved to a new date or time',
+            self::Cancelled => 'Meeting will not take place',
+            self::Partial => 'Left early or joined late',
+        };
+    }
+
+    public function confirmLabel(): string
+    {
+        return match ($this) {
+            self::Attended => 'Mark as attended',
+            self::NoShow => 'Mark as no-show',
+            self::Rescheduled => 'Mark as rescheduled',
+            self::Cancelled => 'Mark as cancelled',
+            self::Partial => 'Mark as partial',
+        };
+    }
+
+    /**
+     * How this outcome should move the follow-up's existing `status` column
+     * (scheduled|completed|cancelled) — kept separate from this enum so the
+     * DB-level status enum never needs an ALTER.
+     */
+    public function followUpStatus(): string
+    {
+        return match ($this) {
+            self::Cancelled => 'cancelled',
+            default => 'completed',
+        };
+    }
+}

--- a/app/Http/Controllers/MeetingAttendanceConfirmationController.php
+++ b/app/Http/Controllers/MeetingAttendanceConfirmationController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\MeetingAttendanceOutcome;
+use App\Models\DealFollowUp;
+use App\Services\MeetingAttendanceConfirmationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MeetingAttendanceConfirmationController extends Controller
+{
+    public function __construct(
+        private readonly MeetingAttendanceConfirmationService $service,
+    ) {
+    }
+
+    /**
+     * The single oldest meeting awaiting an attendance-outcome confirmation
+     * from the current user, or null when nothing is due.
+     */
+    public function pending(): JsonResponse
+    {
+        $followUp = $this->service->pendingForUser(user());
+
+        if (!$followUp) {
+            return response()->json([
+                'status' => 'success',
+                'message' => '',
+                'data' => null,
+            ]);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => '',
+            'data' => $this->present($followUp),
+        ]);
+    }
+
+    public function confirm(Request $request, DealFollowUp $followUp): JsonResponse
+    {
+        if ($followUp->assignedAgentUserId() !== (int) user()->id) {
+            return response()->json([
+                'status' => 'fail',
+                'message' => 'You do not have permission to confirm this meeting.',
+            ], 403);
+        }
+
+        $validated = $request->validate([
+            'outcome' => ['required', 'string', 'in:' . implode(',', array_column(MeetingAttendanceOutcome::cases(), 'value'))],
+            'note' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $outcome = MeetingAttendanceOutcome::from($validated['outcome']);
+
+        $followUp = $this->service->confirm($followUp, user(), $outcome, $validated['note'] ?? null);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Meeting outcome saved.',
+            'data' => [
+                'id' => $followUp->id,
+                'attendance_outcome' => $followUp->attendance_outcome,
+            ],
+        ]);
+    }
+
+    private function present(DealFollowUp $followUp): array
+    {
+        $followUp->loadMissing(['deal.contact', 'lead', 'meetingType']);
+
+        DealFollowUp::attachParticipantUsers(collect([$followUp]));
+
+        $contactName = $followUp->deal?->contact?->client_name
+            ?? $followUp->lead?->client_name
+            ?? null;
+
+        return [
+            'id' => $followUp->id,
+            'deal_id' => $followUp->deal_id,
+            'lead_id' => $followUp->lead_id,
+            'contact_name' => $contactName,
+            'meeting_type_label' => $followUp->meetingType?->type,
+            'scheduled_at' => $followUp->next_follow_up_date?->toIso8601String(),
+            'duration' => $followUp->effective_duration,
+            'location' => $followUp->location,
+            'meeting_link' => $followUp->meeting_link,
+            'remark' => $followUp->remark,
+            'participants' => $followUp->participant_users,
+        ];
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -251,6 +251,7 @@ class Company extends BaseModel
     protected $casts = [
         'google_calendar_status' => 'string',
         'package_pipeline_routing_trigger_fields' => 'array',
+        'meeting_attendance_confirmation_enabled_at' => 'datetime',
     ];
     protected $appends = [
         'logo_url',

--- a/app/Models/DealFollowUp.php
+++ b/app/Models/DealFollowUp.php
@@ -93,6 +93,9 @@ class DealFollowUp extends BaseModel
         'participants',  // JSON field for meeting participants (user IDs)
         'status',
         'duration',  // Meeting duration in minutes (nullable, defaults to 30)
+        'attendance_outcome',
+        'attendance_outcome_logged_at',
+        'attendance_outcome_logged_by',
     ];
 
     protected $casts = [
@@ -101,6 +104,7 @@ class DealFollowUp extends BaseModel
         'reminders' => 'array',  // Cast JSON to array
         'participants' => 'array',  // Cast JSON to array
         'duration' => 'integer',
+        'attendance_outcome_logged_at' => 'datetime',
     ];
 
     /** Default meeting duration (minutes) when none is set */
@@ -162,6 +166,33 @@ class DealFollowUp extends BaseModel
     public function getEffectiveDuration(): int
     {
         return $this->duration ?? self::DEFAULT_DURATION_MINUTES;
+    }
+
+    /**
+     * Computed end time (next_follow_up_date + effective duration). Null when
+     * the meeting has no scheduled date. There is no end_time column.
+     */
+    public function getEndTime(): ?\Carbon\CarbonInterface
+    {
+        if (!$this->next_follow_up_date) {
+            return null;
+        }
+
+        return $this->next_follow_up_date->copy()->addMinutes($this->getEffectiveDuration());
+    }
+
+    /**
+     * The user this meeting is "assigned" to for prompts/reminders: the deal's
+     * lead agent, falling back to the lead owner for lead-only follow-ups.
+     * Mirrors MeetingReminderSync::buildRecipients()'s resolution.
+     */
+    public function assignedAgentUserId(): ?int
+    {
+        $this->loadMissing(['deal.leadAgent', 'lead']);
+
+        $agentUserId = $this->deal?->leadAgent?->user_id ?? $this->lead?->lead_owner;
+
+        return $agentUserId ? (int) $agentUserId : null;
     }
 
     public function addedBy(): BelongsTo

--- a/app/Models/DealFollowUp.php
+++ b/app/Models/DealFollowUp.php
@@ -93,9 +93,6 @@ class DealFollowUp extends BaseModel
         'participants',  // JSON field for meeting participants (user IDs)
         'status',
         'duration',  // Meeting duration in minutes (nullable, defaults to 30)
-        'attendance_outcome',
-        'attendance_outcome_logged_at',
-        'attendance_outcome_logged_by',
     ];
 
     protected $casts = [

--- a/app/Services/DealActivityEventService.php
+++ b/app/Services/DealActivityEventService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\CrmEventGenerationType;
 use App\Enums\CrmEventSource;
+use App\Enums\MeetingAttendanceOutcome;
 use App\Models\CrmEvent;
 use App\Models\Deal;
 use App\Models\DealFollowUp;
@@ -102,6 +103,39 @@ class DealActivityEventService
             'remark' => $followUp->remark,
             'added_by' => $followUp->added_by,
         ]);
+    }
+
+    /**
+     * Records the outcome-change itself. The remark text (if any) is created as
+     * its own DealNote by MeetingAttendanceConfirmationService — DealNoteObserver
+     * already records that as a separate `deal_note_added` timeline entry, so
+     * only a cross-reference id is carried here, not the note text.
+     */
+    public function recordMeetingOutcomeLogged(
+        Deal $deal,
+        DealFollowUp $followUp,
+        MeetingAttendanceOutcome $outcome,
+        ?int $noteId = null
+    ): void {
+        Log::info('[DealActivityEventService::recordMeetingOutcomeLogged] Called.', [
+            'deal_id' => $deal->id,
+            'followup_id' => $followUp->id,
+            'outcome' => $outcome->value,
+            'company_id' => $deal->company_id,
+        ]);
+
+        $meetingTypeName = trim((string) ($followUp->meetingType?->type ?? ''));
+        $meetingLabel = $meetingTypeName !== '' ? $meetingTypeName : 'Follow-up';
+
+        $this->record('deal_meeting_outcome_logged', $deal, [
+            'comment' => $meetingLabel . ': ' . $outcome->label(),
+            'followup_id' => $followUp->id,
+            'meeting_type_id' => $followUp->meeting_type_id,
+            'meeting_type_name' => $meetingTypeName !== '' ? $meetingTypeName : null,
+            'outcome' => $outcome->value,
+            'outcome_label' => $outcome->label(),
+            'note_id' => $noteId,
+        ], $this->generationTypeForCurrentUser());
     }
 
     public function recordTaskCreated(Deal $deal, Task $task): void

--- a/app/Services/MeetingAttendanceConfirmationService.php
+++ b/app/Services/MeetingAttendanceConfirmationService.php
@@ -9,6 +9,7 @@ use App\Models\DealFollowUp;
 use App\Models\DealNote;
 use App\Models\User;
 use App\Support\MeetingAttendanceConfirmationFeature;
+use Illuminate\Support\Facades\DB;
 
 class MeetingAttendanceConfirmationService
 {
@@ -49,9 +50,13 @@ class MeetingAttendanceConfirmationService
         // since duration is per-row and defaults in PHP, not SQL.
         $candidates = DealFollowUp::query()
             ->whereNull('attendance_outcome_logged_at')
-            ->where('status', '!=', 'cancelled')
+            ->where(function ($query) {
+                $query->whereNull('status')
+                    ->orWhere('status', '!=', 'cancelled');
+            })
             ->whereNotNull('next_follow_up_date')
             ->where('next_follow_up_date', '<=', now())
+            ->where('next_follow_up_date', '>=', $activatedAt)
             ->where(function ($query) use ($user, $companyId) {
                 $query->whereHas('deal', function ($dealQuery) use ($user, $companyId) {
                     $dealQuery->where('company_id', $companyId)
@@ -89,27 +94,41 @@ class MeetingAttendanceConfirmationService
     ): DealFollowUp {
         $trimmedNote = $note !== null ? trim($note) : '';
 
-        $followUp->attendance_outcome = $outcome->value;
-        $followUp->attendance_outcome_logged_at = now();
-        $followUp->attendance_outcome_logged_by = $user->id;
-        $followUp->status = $outcome->followUpStatus();
-        $followUp->save();
+        return DB::transaction(function () use ($followUp, $user, $outcome, $trimmedNote) {
+            $loggedAt = now();
 
-        $deal = $followUp->deal ?? ($followUp->deal_id ? Deal::find($followUp->deal_id) : null);
-        if (!$deal) {
+            $claimed = DealFollowUp::query()
+                ->whereKey($followUp->id)
+                ->whereNull('attendance_outcome_logged_at')
+                ->update([
+                    'attendance_outcome' => $outcome->value,
+                    'attendance_outcome_logged_at' => $loggedAt,
+                    'attendance_outcome_logged_by' => $user->id,
+                    'status' => $outcome->followUpStatus(),
+                ]);
+
+            if ($claimed === 0) {
+                return $followUp->fresh();
+            }
+
+            $followUp->refresh();
+
+            $deal = $followUp->deal ?? ($followUp->deal_id ? Deal::find($followUp->deal_id) : null);
+            if (!$deal) {
+                return $followUp;
+            }
+
+            $createdNote = $trimmedNote !== '' ? $this->createNote($deal, $followUp, $trimmedNote) : null;
+
+            $this->dealActivityEventService->recordMeetingOutcomeLogged(
+                $deal,
+                $followUp,
+                $outcome,
+                $createdNote?->id
+            );
+
             return $followUp;
-        }
-
-        $createdNote = $trimmedNote !== '' ? $this->createNote($deal, $followUp, $trimmedNote) : null;
-
-        $this->dealActivityEventService->recordMeetingOutcomeLogged(
-            $deal,
-            $followUp,
-            $outcome,
-            $createdNote?->id
-        );
-
-        return $followUp;
+        });
     }
 
     /**

--- a/app/Services/MeetingAttendanceConfirmationService.php
+++ b/app/Services/MeetingAttendanceConfirmationService.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\MeetingAttendanceOutcome;
+use App\Models\Company;
+use App\Models\Deal;
+use App\Models\DealFollowUp;
+use App\Models\DealNote;
+use App\Models\User;
+use App\Support\MeetingAttendanceConfirmationFeature;
+
+class MeetingAttendanceConfirmationService
+{
+    public function __construct(
+        private readonly DealActivityEventService $dealActivityEventService,
+    ) {
+    }
+
+    /**
+     * The oldest meeting assigned to $user that's still awaiting an attendance
+     * outcome, whose computed end time is at least the configured delay in the
+     * past, and which ended at/after the company's activation cutoff. Returns
+     * null when nothing is eligible (feature off, not yet activated, or no
+     * qualifying meeting).
+     */
+    public function pendingForUser(User $user): ?DealFollowUp
+    {
+        $companyId = $user->company_id ? (int) $user->company_id : null;
+        if (!$companyId) {
+            return null;
+        }
+
+        $company = Company::find($companyId);
+        if (!$company || !MeetingAttendanceConfirmationFeature::enabledForCompany($company)) {
+            return null;
+        }
+
+        $activatedAt = $company->meeting_attendance_confirmation_enabled_at;
+        if (!$activatedAt) {
+            return null;
+        }
+
+        $cutoff = now()->subMinutes(MeetingAttendanceConfirmationFeature::delayMinutes());
+
+        // next_follow_up_date <= now() is a cheap SQL-level upper bound (a meeting
+        // can't have ended before it started); the precise end-time-plus-delay and
+        // activation-cutoff checks happen below via DealFollowUp::getEndTime(),
+        // since duration is per-row and defaults in PHP, not SQL.
+        $candidates = DealFollowUp::query()
+            ->whereNull('attendance_outcome_logged_at')
+            ->where('status', '!=', 'cancelled')
+            ->whereNotNull('next_follow_up_date')
+            ->where('next_follow_up_date', '<=', now())
+            ->where(function ($query) use ($user, $companyId) {
+                $query->whereHas('deal', function ($dealQuery) use ($user, $companyId) {
+                    $dealQuery->where('company_id', $companyId)
+                        ->whereHas('leadAgent', function ($agentQuery) use ($user) {
+                            $agentQuery->where('user_id', $user->id);
+                        });
+                })->orWhereHas('lead', function ($leadQuery) use ($user, $companyId) {
+                    $leadQuery->where('company_id', $companyId)
+                        ->where('lead_owner', $user->id);
+                });
+            })
+            ->with(['deal.leadAgent', 'deal.contact', 'lead', 'meetingType'])
+            ->orderBy('next_follow_up_date')
+            ->limit(20)
+            ->get();
+
+        foreach ($candidates as $followUp) {
+            $endTime = $followUp->getEndTime();
+
+            if (!$endTime || $endTime->gt($cutoff) || $endTime->lt($activatedAt)) {
+                continue;
+            }
+
+            return $followUp;
+        }
+
+        return null;
+    }
+
+    public function confirm(
+        DealFollowUp $followUp,
+        User $user,
+        MeetingAttendanceOutcome $outcome,
+        ?string $note
+    ): DealFollowUp {
+        $trimmedNote = $note !== null ? trim($note) : '';
+
+        $followUp->attendance_outcome = $outcome->value;
+        $followUp->attendance_outcome_logged_at = now();
+        $followUp->attendance_outcome_logged_by = $user->id;
+        $followUp->status = $outcome->followUpStatus();
+        $followUp->save();
+
+        $deal = $followUp->deal ?? ($followUp->deal_id ? Deal::find($followUp->deal_id) : null);
+        if (!$deal) {
+            return $followUp;
+        }
+
+        $createdNote = $trimmedNote !== '' ? $this->createNote($deal, $followUp, $trimmedNote) : null;
+
+        $this->dealActivityEventService->recordMeetingOutcomeLogged(
+            $deal,
+            $followUp,
+            $outcome,
+            $createdNote?->id
+        );
+
+        return $followUp;
+    }
+
+    /**
+     * Remarks left when confirming an outcome are regular deal notes — the
+     * existing DealNoteObserver already records the `deal_note_added` timeline
+     * entry and notifies watchers, the same as the Notes tab's "Add Note".
+     */
+    private function createNote(Deal $deal, DealFollowUp $followUp, string $details): DealNote
+    {
+        $followUp->loadMissing(['deal.contact', 'lead']);
+
+        $contactName = $followUp->deal?->contact?->client_name
+            ?? $followUp->lead?->client_name
+            ?? null;
+
+        $dateLabel = CrmEventDescriptionBuilder::formatDate($followUp->next_follow_up_date);
+
+        $title = $contactName
+            ? "Remark after meeting with {$contactName}" . ($dateLabel !== '--' ? " — {$dateLabel}" : '')
+            : "Remark after meeting" . ($dateLabel !== '--' ? " — {$dateLabel}" : '');
+
+        return DealNote::create([
+            'title' => $title,
+            'deal_id' => $deal->id,
+            'details' => $details,
+        ]);
+    }
+}

--- a/app/Support/MeetingAttendanceConfirmationFeature.php
+++ b/app/Support/MeetingAttendanceConfirmationFeature.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Company;
+use Illuminate\Support\Facades\Cache;
+
+class MeetingAttendanceConfirmationFeature
+{
+    private const ACTIVATION_STAMPED_CACHE_TTL = 3600;
+
+    /**
+     * Global kill switch for the meeting-attendance-confirmation prompt.
+     * Prefer the remote feature flag; MEETING_ATTENDANCE_CONFIRMATION_FORCE_ENABLE
+     * bypasses it when the flags API is down or the flag is not yet rolled out remotely.
+     */
+    public static function globallyEnabled(): bool
+    {
+        if ((bool) config('meetings.attendance_confirmation_force_enable', false)) {
+            return true;
+        }
+
+        return FeatureFlags::enabled('crm.meeting-attendance-confirmation');
+    }
+
+    /**
+     * Enabled for this company right now (flag + allowlist). Also lazily stamps
+     * companies.meeting_attendance_confirmation_enabled_at the first time this
+     * returns true for the company, so meetings that ended before the feature
+     * was actually turned on for this company never become eligible later.
+     */
+    public static function enabledForCompany(Company|int $company): bool
+    {
+        if (!self::globallyEnabled()) {
+            return false;
+        }
+
+        $companyId = $company instanceof Company ? (int) $company->id : (int) $company;
+
+        if (!self::companyInAllowlist($companyId)) {
+            return false;
+        }
+
+        self::ensureActivationStamped($company instanceof Company ? $company : $companyId);
+
+        return true;
+    }
+
+    public static function companyInAllowlist(int $companyId): bool
+    {
+        $raw = trim((string) config('meetings.attendance_confirmation_company_allowlist', ''));
+
+        if ($raw === '') {
+            return false;
+        }
+
+        if ($raw === '*') {
+            return true;
+        }
+
+        $ids = array_filter(array_map('intval', preg_split('/\s*,\s*/', $raw) ?: []));
+
+        return in_array($companyId, $ids, true);
+    }
+
+    public static function delayMinutes(): int
+    {
+        return (int) config('meetings.attendance_confirmation_delay_minutes', 5);
+    }
+
+    /**
+     * When this call performs the write, also patches the in-memory $company
+     * instance (if one was passed in) — otherwise a caller that already fetched
+     * $company before this call would read a stale null back from it on the
+     * very same request that just activated the feature.
+     */
+    private static function ensureActivationStamped(Company|int $company): void
+    {
+        $companyId = $company instanceof Company ? (int) $company->id : (int) $company;
+        $cacheKey = "meeting_attendance_confirmation:activated:{$companyId}";
+
+        if (Cache::get($cacheKey)) {
+            return;
+        }
+
+        $now = now();
+        $updated = Company::query()
+            ->where('id', $companyId)
+            ->whereNull('meeting_attendance_confirmation_enabled_at')
+            ->update(['meeting_attendance_confirmation_enabled_at' => $now]);
+
+        if ($updated && $company instanceof Company) {
+            $company->meeting_attendance_confirmation_enabled_at = $now;
+        }
+
+        Cache::put($cacheKey, true, self::ACTIVATION_STAMPED_CACHE_TTL);
+    }
+}

--- a/config/crm_events.php
+++ b/config/crm_events.php
@@ -329,6 +329,22 @@ return [
             'sync_processing' => false,
         ],
         [
+            'slug' => 'deal_meeting_outcome_logged',
+            'name' => 'Deal Meeting Outcome Logged',
+            'category' => 'deal',
+            'model_type' => 'App\\Models\\Deal',
+            'description' => 'An agent confirmed what happened at a meeting (attended, no-show, rescheduled, cancelled, or partially attended).',
+            'sync_processing' => false,
+            'metadata_schema' => [
+                'followup_id' => ['type' => 'integer', 'label' => 'Follow-Up ID'],
+                'meeting_type_name' => ['type' => 'string', 'label' => 'Meeting Type'],
+                'outcome' => ['type' => 'string', 'label' => 'Outcome'],
+                'outcome_label' => ['type' => 'string', 'label' => 'Outcome Label'],
+                'note_id' => ['type' => 'integer', 'label' => 'Note ID'],
+                'comment' => ['type' => 'string', 'label' => 'Description'],
+            ],
+        ],
+        [
             'slug' => 'deal_task_created',
             'name' => 'Deal Task Created',
             'category' => 'deal',

--- a/config/features.php
+++ b/config/features.php
@@ -33,5 +33,6 @@ return [
         'crm.leads-filter-v2',
         'crm.expose-share-links',
         'crm.tasks-workspace-redesign',
+        'crm.meeting-attendance-confirmation',
     ],
 ];

--- a/config/meetings.php
+++ b/config/meetings.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting attendance confirmation — staged company allowlist
+    |--------------------------------------------------------------------------
+    |
+    | Global kill switch: FeatureFlags::enabled('crm.meeting-attendance-confirmation')
+    | (OFF until enabled in the feature-flag service).
+    |
+    | When ON, only company IDs listed here prompt agents to confirm meeting
+    | outcomes. Everyone else sees no change.
+    |
+    | Empty = no companies. Use * for all companies once verified.
+    | MEETING_ATTENDANCE_CONFIRMATION_COMPANY_ALLOWLIST=123 or 123,456 or *
+    |
+    */
+    'attendance_confirmation_company_allowlist' => trim((string) env('MEETING_ATTENDANCE_CONFIRMATION_COMPANY_ALLOWLIST', '')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bypass remote feature flag
+    |--------------------------------------------------------------------------
+    |
+    | When true, MeetingAttendanceConfirmationFeature ignores
+    | FeatureFlags::enabled('crm.meeting-attendance-confirmation') and still
+    | respects the company allowlist. Use locally when the flags API is
+    | unreachable, or as an ops override.
+    |
+    */
+    'attendance_confirmation_force_enable' => filter_var(env('MEETING_ATTENDANCE_CONFIRMATION_FORCE_ENABLE', false), FILTER_VALIDATE_BOOLEAN),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Confirmation delay
+    |--------------------------------------------------------------------------
+    |
+    | Minutes after a meeting's computed end time (next_follow_up_date +
+    | duration) before the attendance-confirmation prompt becomes eligible.
+    |
+    */
+    'attendance_confirmation_delay_minutes' => (int) env('MEETING_ATTENDANCE_CONFIRMATION_DELAY_MINUTES', 5),
+
+];

--- a/database/migrations/2026_08_25_120000_add_attendance_outcome_to_lead_follow_up_table.php
+++ b/database/migrations/2026_08_25_120000_add_attendance_outcome_to_lead_follow_up_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $needsOutcome = !Schema::hasColumn('lead_follow_up', 'attendance_outcome');
+
+        if ($needsOutcome) {
+            Schema::table('lead_follow_up', function (Blueprint $table) {
+                // Post-meeting attendance outcome (attended/no_show/rescheduled/cancelled/partial).
+                // Kept separate from the existing `status` enum (scheduled/completed/cancelled)
+                // rather than extending it, to avoid an ALTER on a DB-level enum column.
+                //
+                // No note column here on purpose: an outcome note is created as a regular
+                // DealNote (the existing notes feature) so it shows up in the deal's Notes
+                // tab/timeline like any other note, instead of living in a shadow field only
+                // visible on the meeting record. See MeetingAttendanceConfirmationService.
+                $table->string('attendance_outcome')->nullable()->after('status');
+                // NULL = still pending confirmation; non-null = resolved, never prompt again.
+                $table->timestamp('attendance_outcome_logged_at')->nullable()->after('attendance_outcome');
+                $table->unsignedInteger('attendance_outcome_logged_by')->nullable()->after('attendance_outcome_logged_at');
+
+                $table->foreign('attendance_outcome_logged_by')
+                    ->references('id')->on('users')
+                    ->onDelete('set null');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $hasOutcome = Schema::hasColumn('lead_follow_up', 'attendance_outcome');
+
+        if ($hasOutcome) {
+            Schema::table('lead_follow_up', function (Blueprint $table) {
+                $table->dropForeign(['attendance_outcome_logged_by']);
+                $table->dropColumn([
+                    'attendance_outcome',
+                    'attendance_outcome_logged_at',
+                    'attendance_outcome_logged_by',
+                ]);
+            });
+        }
+    }
+};

--- a/database/migrations/2026_08_25_120001_add_meeting_attendance_confirmation_enabled_at_to_companies_table.php
+++ b/database/migrations/2026_08_25_120001_add_meeting_attendance_confirmation_enabled_at_to_companies_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $needsColumn = !Schema::hasColumn('companies', 'meeting_attendance_confirmation_enabled_at');
+
+        if ($needsColumn) {
+            Schema::table('companies', function (Blueprint $table) {
+                // Stamped once, lazily, the first time the meeting-attendance-confirmation
+                // feature is observed enabled for this company. Meetings that ended before
+                // this timestamp are never eligible for the confirmation prompt, even after
+                // the feature flag is on — this is the non-retroactivity cutoff.
+                $table->timestamp('meeting_attendance_confirmation_enabled_at')->nullable();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $hasColumn = Schema::hasColumn('companies', 'meeting_attendance_confirmation_enabled_at');
+
+        if ($hasColumn) {
+            Schema::table('companies', function (Blueprint $table) {
+                $table->dropColumn('meeting_attendance_confirmation_enabled_at');
+            });
+        }
+    }
+};

--- a/resources/js/Components/MeetingAttendanceConfirmation/MeetingAttendanceConfirmationModal.tsx
+++ b/resources/js/Components/MeetingAttendanceConfirmation/MeetingAttendanceConfirmationModal.tsx
@@ -1,0 +1,536 @@
+import { useMemo, useState, type CSSProperties } from "react";
+import dayjs from "dayjs";
+import TaskModalShell from "@/Pages/Tasks/Redesign/components/primitives/TaskModalShell";
+import UserIndicator, { getInitials } from "@/Components/UserIndicator";
+import { useTd } from "@/Hooks/useDynamicTranslation";
+import { useApiMutate } from "@/lib/api/client";
+import { ApiResponse } from "@/lib/api/types";
+import { formatCompanyDate, formatCompanyTime } from "@/lib/companyDateTime";
+import type {
+    MeetingAttendanceOutcome,
+    PendingMeetingAttendanceConfirmation,
+} from "@/Types/api/meeting-attendance-confirmation";
+
+interface OutcomeDef {
+    key: MeetingAttendanceOutcome;
+    label: string;
+    helper: string;
+    tone: { c: string; bg: string; bd: string };
+    icon: React.ReactNode;
+}
+
+const TONE = {
+    green: { c: "#177a5b", bg: "#e1f5ee", bd: "#9fe1cb" },
+    red: { c: "#b91c1c", bg: "#fef2f2", bd: "#fecaca" },
+    amber: { c: "#92400e", bg: "#fef3c7", bd: "#fed7aa" },
+    gray: { c: "#5b6472", bg: "#f5f6f8", bd: "#e8eaed" },
+    teal: { c: "#0f766e", bg: "#e6f7f5", bd: "#99e2d8" },
+};
+
+interface MeetingAttendanceConfirmationModalProps {
+    meeting: PendingMeetingAttendanceConfirmation;
+    onDismiss: () => void;
+    onConfirmed: () => void;
+}
+
+export default function MeetingAttendanceConfirmationModal({
+    meeting,
+    onDismiss,
+    onConfirmed,
+}: MeetingAttendanceConfirmationModalProps) {
+    const { td } = useTd();
+    const [selected, setSelected] = useState<MeetingAttendanceOutcome | null>(
+        null,
+    );
+    const [note, setNote] = useState("");
+
+    const outcomes: OutcomeDef[] = useMemo(
+        () => [
+            {
+                key: "attended",
+                label: td("Attended", { source: "en" }),
+                helper: td("Showed up as planned", { source: "en" }),
+                tone: TONE.green,
+                icon: <path d="M20 6 9 17l-5-5" />,
+            },
+            {
+                key: "no_show",
+                label: td("Did not attend (no-show)", { source: "en" }),
+                helper: td("Missed it without notice", { source: "en" }),
+                tone: TONE.red,
+                icon: (
+                    <>
+                        <path d="M18 6 6 18" />
+                        <path d="M6 6l12 12" />
+                    </>
+                ),
+            },
+            {
+                key: "rescheduled",
+                label: td("Rescheduled / postponed", { source: "en" }),
+                helper: td("Moved to a new date or time", { source: "en" }),
+                tone: TONE.amber,
+                icon: (
+                    <>
+                        <path d="M3 12a9 9 0 0 1 15.5-6.2L21 8" />
+                        <path d="M21 3v5h-5" />
+                        <path d="M21 12a9 9 0 0 1-15.5 6.2L3 16" />
+                        <path d="M3 21v-5h5" />
+                    </>
+                ),
+            },
+            {
+                key: "cancelled",
+                label: td("Cancelled", { source: "en" }),
+                helper: td("Meeting will not take place", { source: "en" }),
+                tone: TONE.gray,
+                icon: (
+                    <>
+                        <path d="M8 2v4" />
+                        <path d="M16 2v4" />
+                        <path d="M3 10h18" />
+                        <path d="M5 4h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z" />
+                        <path d="m9 15 6-6" />
+                        <path d="m9 9 6 6" />
+                    </>
+                ),
+            },
+            {
+                key: "partial",
+                label: td("Partially attended", { source: "en" }),
+                helper: td("Left early or joined late", { source: "en" }),
+                tone: TONE.teal,
+                icon: (
+                    <>
+                        <path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18z" />
+                        <path d="M12 7v5l3 2" />
+                    </>
+                ),
+            },
+        ],
+        [td],
+    );
+
+    const confirmLabels: Record<MeetingAttendanceOutcome, string> = {
+        attended: td("Mark as attended", { source: "en" }),
+        no_show: td("Mark as no-show", { source: "en" }),
+        rescheduled: td("Mark as rescheduled", { source: "en" }),
+        cancelled: td("Mark as cancelled", { source: "en" }),
+        partial: td("Mark as partial", { source: "en" }),
+    };
+
+    const confirmMutation = useApiMutate<
+        { outcome: MeetingAttendanceOutcome; note: string | null },
+        { id: number },
+        ApiResponse<{ id: number }>
+    >(
+        route("meetings.api.attendance_confirmation.confirm", {
+            followUp: meeting.id,
+        }),
+        "POST",
+        () => onConfirmed(),
+    );
+
+    const selectedOutcome = outcomes.find((o) => o.key === selected) ?? null;
+    const contactName = meeting.contact_name || td("this contact", { source: "en" });
+    const meetingTypeLabel = meeting.meeting_type_label?.trim();
+    const title = meetingTypeLabel
+        ? td(`Did ${contactName} attend the ${meetingTypeLabel} meeting?`)
+        : td(`Did ${contactName} attend the meeting?`);
+
+    const scheduled = meeting.scheduled_at ? dayjs(meeting.scheduled_at) : null;
+    const noteLabel = td(
+        `Remark after meeting with ${contactName} — ${
+            scheduled ? formatCompanyDate(meeting.scheduled_at) : ""
+        }`,
+    );
+
+    const handleConfirm = () => {
+        if (!selectedOutcome || confirmMutation.isPending) return;
+        confirmMutation.mutate({
+            outcome: selectedOutcome.key,
+            note: note.trim() !== "" ? note.trim() : null,
+        });
+    };
+
+    const rowStyle = (active: boolean): CSSProperties => ({
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        width: "100%",
+        padding: "11px 13px",
+        borderRadius: 10,
+        cursor: "pointer",
+        fontFamily: "var(--font-sans, inherit)",
+        textAlign: "left",
+        background: active ? "#e8f1fb" : "#ffffff",
+        border: `1px solid ${active ? "#b8d4f0" : "#e2e5ea"}`,
+        boxShadow: active ? "0 0 0 2px #e8f1fb" : "none",
+        transition:
+            "background 120ms ease, border-color 120ms ease, box-shadow 120ms ease",
+    });
+
+    return (
+        <TaskModalShell
+            open
+            onClose={onDismiss}
+            ariaLabel={title}
+            zIndex={1000}
+            panelStyle={{
+                width: "100%",
+                maxWidth: 480,
+                background: "#ffffff",
+                borderRadius: 14,
+                boxShadow: "0 20px 50px rgba(22,41,77,0.18)",
+                overflow: "hidden",
+            }}
+        >
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 12,
+                    padding: "16px 22px 14px",
+                    background: "#f8f9fb",
+                    borderBottom: "1px solid #eef0f3",
+                }}
+            >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            fontSize: 12,
+                            fontWeight: 600,
+                            letterSpacing: "0.03em",
+                            textTransform: "uppercase",
+                            color: "#14538c",
+                        }}
+                    >
+                        {td("Follow-up reminder", { source: "en" })}
+                    </div>
+                    <div
+                        style={{
+                            fontSize: 16,
+                            fontWeight: 700,
+                            color: "#16294d",
+                            lineHeight: 1.3,
+                            marginTop: 5,
+                        }}
+                    >
+                        {title}
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    aria-label={td("Close", { source: "en" })}
+                    onClick={onDismiss}
+                    style={{
+                        background: "none",
+                        border: "none",
+                        padding: 4,
+                        margin: "-2px -6px 0 0",
+                        cursor: "pointer",
+                        color: "#5b6472",
+                        display: "flex",
+                        borderRadius: 6,
+                    }}
+                >
+                    <svg
+                        width="17"
+                        height="17"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <path d="M18 6 6 18" />
+                        <path d="M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+
+            <div style={{ padding: "18px 22px 20px", maxHeight: "70vh", overflowY: "auto" }}>
+                <div
+                    style={{
+                        display: "flex",
+                        gap: 12,
+                        alignItems: "flex-start",
+                        padding: 14,
+                        border: "1px solid #e2e5ea",
+                        borderRadius: 10,
+                        background: "#f8f9fb",
+                    }}
+                >
+                    {scheduled && (
+                        <div
+                            style={{
+                                width: 48,
+                                borderRadius: 12,
+                                overflow: "hidden",
+                                flexShrink: 0,
+                                textAlign: "center",
+                                border: "1px solid #b8d4f0",
+                                background: "#e8f1fb",
+                            }}
+                        >
+                            <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.05em", textTransform: "uppercase", color: "#14538c", padding: "4px 0 2px" }}>
+                                {scheduled.format("MMM").toUpperCase()}
+                            </div>
+                            <div style={{ fontSize: 19, fontWeight: 700, lineHeight: 1.1, color: "#16294d" }}>
+                                {scheduled.format("D")}
+                            </div>
+                            <div style={{ fontSize: 12, color: "#5b6472", paddingBottom: 5 }}>
+                                {scheduled.format("ddd")}
+                            </div>
+                        </div>
+                    )}
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                            <span style={{ fontSize: 15, fontWeight: 700, color: "#1a1f2e" }}>
+                                {meetingTypeLabel || td("Meeting", { source: "en" })}
+                            </span>
+                        </div>
+                        <div style={{ fontSize: 13, color: "#5b6472", marginTop: 5, lineHeight: 1.5 }}>
+                            {scheduled ? formatCompanyTime(meeting.scheduled_at) : "--"}
+                            {meeting.duration ? ` (${meeting.duration} ${td("min", { source: "en" })})` : ""}
+                            {" · "}
+                            {meeting.meeting_link
+                                ? td("Online", { source: "en" })
+                                : td("On site", { source: "en" })}
+                        </div>
+                        {meeting.location && (
+                            <div style={{ fontSize: 13, color: "#5b6472", marginTop: 2, lineHeight: 1.5 }}>
+                                {meeting.location}
+                            </div>
+                        )}
+                        {(meeting.contact_name || meeting.participants.length > 0) && (
+                            <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 11, flexWrap: "wrap" }}>
+                                {meeting.contact_name && (
+                                    <span
+                                        style={{
+                                            width: 26,
+                                            height: 26,
+                                            borderRadius: 999,
+                                            display: "inline-flex",
+                                            alignItems: "center",
+                                            justifyContent: "center",
+                                            fontWeight: 700,
+                                            fontSize: 11,
+                                            background: "#177a5b",
+                                            color: "#fff",
+                                            boxShadow: "0 0 0 2px #fff",
+                                        }}
+                                        title={meeting.contact_name}
+                                    >
+                                        {getInitials(meeting.contact_name)}
+                                    </span>
+                                )}
+                                {meeting.participants.map((participant) => (
+                                    <UserIndicator
+                                        key={participant.id}
+                                        data={participant}
+                                        size="xs"
+                                        showTooltip
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 16 }}>
+                    {selectedOutcome === null &&
+                        outcomes.map((outcome) => (
+                            <button
+                                key={outcome.key}
+                                type="button"
+                                onClick={() => setSelected(outcome.key)}
+                                style={rowStyle(false)}
+                            >
+                                <span
+                                    style={{
+                                        width: 32,
+                                        height: 32,
+                                        borderRadius: 8,
+                                        flexShrink: 0,
+                                        display: "inline-flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        background: outcome.tone.bg,
+                                        border: `1px solid ${outcome.tone.bd}`,
+                                    }}
+                                >
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={outcome.tone.c} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                                        {outcome.icon}
+                                    </svg>
+                                </span>
+                                <span style={{ flex: 1, minWidth: 0, textAlign: "left" }}>
+                                    <span style={{ display: "block", fontSize: 14, fontWeight: 600, color: "#1a1f2e" }}>
+                                        {outcome.label}
+                                    </span>
+                                    <span style={{ display: "block", fontSize: 12, color: "#5b6472", marginTop: 1 }}>
+                                        {outcome.helper}
+                                    </span>
+                                </span>
+                            </button>
+                        ))}
+
+                    {selectedOutcome !== null && (
+                        <>
+                            <div style={rowStyle(true)}>
+                                <span
+                                    style={{
+                                        width: 32,
+                                        height: 32,
+                                        borderRadius: 8,
+                                        flexShrink: 0,
+                                        display: "inline-flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        background: selectedOutcome.tone.bg,
+                                        border: `1px solid ${selectedOutcome.tone.bd}`,
+                                    }}
+                                >
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={selectedOutcome.tone.c} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                                        {selectedOutcome.icon}
+                                    </svg>
+                                </span>
+                                <span style={{ flex: 1, minWidth: 0, textAlign: "left" }}>
+                                    <span style={{ display: "block", fontSize: 14, fontWeight: 600, color: "#1a1f2e" }}>
+                                        {selectedOutcome.label}
+                                    </span>
+                                    <span style={{ display: "block", fontSize: 12, color: "#5b6472", marginTop: 1 }}>
+                                        {selectedOutcome.helper}
+                                    </span>
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => setSelected(null)}
+                                    style={{
+                                        background: "none",
+                                        border: "none",
+                                        color: "#1a6bb5",
+                                        fontSize: 12,
+                                        fontWeight: 600,
+                                        cursor: "pointer",
+                                        padding: "4px 6px",
+                                        flexShrink: 0,
+                                    }}
+                                >
+                                    {td("Change", { source: "en" })}
+                                </button>
+                            </div>
+
+                            <div style={{ marginTop: 4 }}>
+                                <label
+                                    htmlFor="meeting-attendance-note"
+                                    style={{
+                                        display: "block",
+                                        fontSize: 12,
+                                        fontWeight: 700,
+                                        letterSpacing: "0.05em",
+                                        textTransform: "uppercase",
+                                        color: "#5b6472",
+                                        marginBottom: 6,
+                                    }}
+                                >
+                                    {noteLabel}
+                                </label>
+                                <textarea
+                                    id="meeting-attendance-note"
+                                    value={note}
+                                    onChange={(event) => setNote(event.target.value)}
+                                    placeholder={td("Add an optional note…", { source: "en" })}
+                                    rows={3}
+                                    style={{
+                                        width: "100%",
+                                        resize: "vertical",
+                                        border: "1px solid #e2e5ea",
+                                        borderRadius: 8,
+                                        padding: "10px 12px",
+                                        fontFamily: "inherit",
+                                        fontSize: 13,
+                                        color: "#1a1f2e",
+                                    }}
+                                />
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    padding: "14px 22px",
+                    borderTop: "1px solid #eef0f3",
+                    background: "#ffffff",
+                }}
+            >
+                <span style={{ fontSize: 12, color: "#9ca3af" }}>
+                    {selectedOutcome
+                        ? td("Logged to this lead's timeline", { source: "en" })
+                        : td("Select an outcome to continue", { source: "en" })}
+                </span>
+                <span style={{ display: "flex", gap: 8 }}>
+                    <button
+                        type="button"
+                        onClick={onDismiss}
+                        style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            gap: 7,
+                            fontSize: 13,
+                            fontWeight: 600,
+                            lineHeight: 1.2,
+                            padding: "9px 16px",
+                            minHeight: 32,
+                            borderRadius: 8,
+                            cursor: "pointer",
+                            background: "#ffffff",
+                            color: "#5b6472",
+                            border: "1px solid #e2e5ea",
+                        }}
+                    >
+                        {td("Cancel", { source: "en" })}
+                    </button>
+                    <button
+                        type="button"
+                        disabled={!selectedOutcome || confirmMutation.isPending}
+                        onClick={handleConfirm}
+                        style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            gap: 7,
+                            fontSize: 13,
+                            fontWeight: 600,
+                            lineHeight: 1.2,
+                            padding: "9px 16px",
+                            minHeight: 32,
+                            borderRadius: 8,
+                            background: "#1a6bb5",
+                            color: "#ffffff",
+                            border: "1px solid #1a6bb5",
+                            cursor:
+                                !selectedOutcome || confirmMutation.isPending
+                                    ? "not-allowed"
+                                    : "pointer",
+                            opacity: !selectedOutcome || confirmMutation.isPending ? 0.45 : 1,
+                        }}
+                    >
+                        {selectedOutcome ? confirmLabels[selectedOutcome.key] : td("Confirm", { source: "en" })}
+                    </button>
+                </span>
+            </div>
+        </TaskModalShell>
+    );
+}

--- a/resources/js/Components/MeetingAttendanceConfirmation/MeetingAttendanceConfirmationMount.tsx
+++ b/resources/js/Components/MeetingAttendanceConfirmation/MeetingAttendanceConfirmationMount.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { usePage } from "@inertiajs/react";
+import type { PageProps } from "@/Components/DashboardLayout";
+import useMeetingAttendanceConfirmationFlag from "@/Hooks/useMeetingAttendanceConfirmationFlag";
+import { useMeetingAttendanceConfirmation } from "@/Hooks/useMeetingAttendanceConfirmation";
+import MeetingAttendanceConfirmationModal from "./MeetingAttendanceConfirmationModal";
+
+/** Skips guest pages and companies the flag isn't enabled for — no polling before login. */
+export function MeetingAttendanceConfirmationMount(): ReactNode {
+    const { props } = usePage<PageProps>();
+    const flagEnabled = useMeetingAttendanceConfirmationFlag();
+
+    if (!props.auth?.user || !flagEnabled) return null;
+
+    return <AuthenticatedMeetingAttendanceConfirmation />;
+}
+
+function AuthenticatedMeetingAttendanceConfirmation(): ReactNode {
+    const { current, dismiss, resolve } = useMeetingAttendanceConfirmation(true);
+
+    if (!current) return null;
+
+    return (
+        <MeetingAttendanceConfirmationModal
+            meeting={current}
+            onDismiss={() => dismiss(current.id)}
+            onConfirmed={() => {
+                dismiss(current.id);
+                resolve();
+            }}
+        />
+    );
+}

--- a/resources/js/Hooks/useMeetingAttendanceConfirmation.ts
+++ b/resources/js/Hooks/useMeetingAttendanceConfirmation.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { useApiQuery } from "@/lib/api/client";
+import { ApiResponse, isSuccessResponse } from "@/lib/api/types";
+import { PendingMeetingAttendanceConfirmation } from "@/Types/api/meeting-attendance-confirmation";
+
+const POLL_MS = 60_000;
+
+/**
+ * Polls for a single pending meeting-attendance confirmation for the current
+ * user. Dismissing (Cancel/Close, no outcome chosen) only hides it for this
+ * browser session — the server still considers it unresolved and it resurfaces
+ * on the next session/page load.
+ */
+export function useMeetingAttendanceConfirmation(enabled: boolean) {
+    const [dismissedIds, setDismissedIds] = useState<Set<number>>(new Set());
+
+    const { data: response, refetch } = useApiQuery<
+        ApiResponse<PendingMeetingAttendanceConfirmation | null>
+    >({
+        path: route("meetings.api.attendance_confirmation.pending"),
+        options: { enabled, refetchInterval: enabled ? POLL_MS : false },
+    });
+
+    const pending =
+        response && isSuccessResponse(response) ? response.data ?? null : null;
+
+    const current = pending && !dismissedIds.has(pending.id) ? pending : null;
+
+    const dismiss = useCallback((id: number) => {
+        setDismissedIds((prev) => {
+            const next = new Set(prev);
+            next.add(id);
+            return next;
+        });
+    }, []);
+
+    /** Call after a successful confirm to immediately pull the next pending meeting, if any. */
+    const resolve = useCallback(() => {
+        refetch();
+    }, [refetch]);
+
+    return { current, dismiss, resolve };
+}

--- a/resources/js/Hooks/useMeetingAttendanceConfirmationFlag.ts
+++ b/resources/js/Hooks/useMeetingAttendanceConfirmationFlag.ts
@@ -1,0 +1,9 @@
+import { usePage } from "@inertiajs/react";
+import type { PageProps } from "@/Components/DashboardLayout";
+import { MEETING_ATTENDANCE_CONFIRMATION_FLAG } from "@/lib/meetingAttendanceConfirmationFlag";
+
+export default function useMeetingAttendanceConfirmationFlag(): boolean {
+    const { props } = usePage<PageProps>();
+
+    return props.featureFlags?.[MEETING_ATTENDANCE_CONFIRMATION_FLAG] === true;
+}

--- a/resources/js/Types/api/meeting-attendance-confirmation.ts
+++ b/resources/js/Types/api/meeting-attendance-confirmation.ts
@@ -1,0 +1,32 @@
+export type MeetingAttendanceOutcome =
+    | "attended"
+    | "no_show"
+    | "rescheduled"
+    | "cancelled"
+    | "partial";
+
+export interface PendingMeetingAttendanceParticipant {
+    id: number;
+    name: string;
+    email?: string;
+    image_url?: string;
+}
+
+export interface PendingMeetingAttendanceConfirmation {
+    id: number;
+    deal_id: number | null;
+    lead_id: number | null;
+    contact_name: string | null;
+    meeting_type_label: string | null;
+    scheduled_at: string | null;
+    duration: number;
+    location: string | null;
+    meeting_link: string | null;
+    remark: string | null;
+    participants: PendingMeetingAttendanceParticipant[];
+}
+
+export interface MeetingAttendanceConfirmationPayload {
+    outcome: MeetingAttendanceOutcome;
+    note?: string | null;
+}

--- a/resources/js/lib/meetingAttendanceConfirmationFlag.ts
+++ b/resources/js/lib/meetingAttendanceConfirmationFlag.ts
@@ -1,0 +1,2 @@
+export const MEETING_ATTENDANCE_CONFIRMATION_FLAG =
+    "crm.meeting-attendance-confirmation";

--- a/resources/js/providers/index.tsx
+++ b/resources/js/providers/index.tsx
@@ -9,6 +9,7 @@ import { CompanyDateTimeProvider } from "@/Components/CompanyDateTimeProvider";
 import NotificationAlertProvider from "@/Components/NotificationAlertProvider";
 import { NotificationAlertBridgeMount } from "@/Hooks/useNotificationAlertBridge";
 import useNotificationIslandAlertsFlag from "@/Hooks/useNotificationIslandAlertsFlag";
+import { MeetingAttendanceConfirmationMount } from "@/Components/MeetingAttendanceConfirmation/MeetingAttendanceConfirmationMount";
 import { NotificationAlertSettingsProvider } from "@/contexts/NotificationAlertSettingsContext";
 
 function NotificationAlertsGate({
@@ -57,6 +58,7 @@ export const InnerProviders: React.FC<{ children: React.ReactNode }> = ({
                         <FilterProvider>
                             <NotificationAlertSettingsProvider>
                                 <NotificationAlertsGate>
+                                    <MeetingAttendanceConfirmationMount />
                                     {children}
                                 </NotificationAlertsGate>
                             </NotificationAlertSettingsProvider>

--- a/routes/web.php
+++ b/routes/web.php
@@ -750,6 +750,12 @@ Route::group(['middleware' => 'auth', 'prefix' => 'account'], function () {
     Route::get('meetings/lead/{lead}', [\App\Http\Controllers\MeetingsController::class, 'getLeadForScheduling'])->name('meetings.lead_for_scheduling');
     Route::post('meetings/{followUp}/reschedule', [\App\Http\Controllers\MeetingsController::class, 'reschedule'])->name('meetings.reschedule');
 
+    // Meeting attendance confirmation (5-minutes-after-meeting-ends popup)
+    Route::prefix('api/meetings')->name('meetings.api.')->group(function () {
+        Route::get('/attendance-confirmation/pending', [\App\Http\Controllers\MeetingAttendanceConfirmationController::class, 'pending'])->name('attendance_confirmation.pending');
+        Route::post('/{followUp}/attendance-confirmation', [\App\Http\Controllers\MeetingAttendanceConfirmationController::class, 'confirm'])->name('attendance_confirmation.confirm');
+    });
+
     // Meeting Summary Routes
     Route::get('meeting-summary/{summaryId}', [MeetingSummaryController::class, 'show'])->name('meeting-summary.show');
 

--- a/tests/Unit/Meetings/MeetingAttendanceConfirmationServiceTest.php
+++ b/tests/Unit/Meetings/MeetingAttendanceConfirmationServiceTest.php
@@ -132,7 +132,10 @@ class MeetingAttendanceConfirmationServiceTest extends TestCase
         // already in place rather than reading it stale.
         $this->makeFollowUp(1, endedMinutesAgo: 30);
 
-        $this->service->pendingForUser($this->agent());
+        $this->assertNull(
+            $this->service->pendingForUser($this->agent()),
+            'A meeting that ended before activation was stamped must not be eligible on the same call.'
+        );
 
         $company = Company::query()->find(10);
         $this->assertNotNull(

--- a/tests/Unit/Meetings/MeetingAttendanceConfirmationServiceTest.php
+++ b/tests/Unit/Meetings/MeetingAttendanceConfirmationServiceTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Unit\Meetings;
+
+use App\Models\Company;
+use App\Models\User;
+use App\Services\MeetingAttendanceConfirmationService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Concerns\SetsFeatureFlags;
+use Tests\TestCase;
+
+/**
+ * The eligibility window ("ended >= 5 minutes ago") and the non-retroactivity
+ * cutoff (never prompt for a meeting that ended before the feature was turned
+ * on for the company) are the two hard requirements for this feature — this
+ * test is about proving both hold, not general CRUD coverage.
+ */
+class MeetingAttendanceConfirmationServiceTest extends TestCase
+{
+    use SetsFeatureFlags;
+
+    private MeetingAttendanceConfirmationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('database.default', 'sqlite');
+        Config::set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->resetSchema();
+        $this->createMinimalSchema();
+
+        Cache::flush();
+        Config::set('meetings.attendance_confirmation_company_allowlist', '10');
+        $this->setFeatureFlag('crm.meeting-attendance-confirmation', true);
+
+        DB::table('companies')->insert(['id' => 10, 'company_name' => 'Acme']);
+        DB::table('users')->insert(['id' => 5, 'company_id' => 10, 'name' => 'Agent', 'email' => 'agent@example.test']);
+        DB::table('users')->insert(['id' => 6, 'company_id' => 10, 'name' => 'Other Agent', 'email' => 'other@example.test']);
+        DB::table('lead_agents')->insert(['id' => 1, 'user_id' => 5]);
+        DB::table('lead_agents')->insert(['id' => 2, 'user_id' => 6]);
+        DB::table('leads')->insert(['id' => 1, 'company_id' => 10, 'client_name' => 'Daniel Rivas', 'lead_owner' => 5]);
+        DB::table('deals')->insert(['id' => 1, 'company_id' => 10, 'agent_id' => 1, 'lead_id' => 1]);
+
+        $this->service = app(MeetingAttendanceConfirmationService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetSchema();
+        parent::tearDown();
+    }
+
+    public function test_meeting_not_yet_five_minutes_past_end_is_not_eligible(): void
+    {
+        $this->activateCompany(10, now()->subDay());
+        $this->makeFollowUp(1, endedMinutesAgo: 4);
+
+        $this->assertNull($this->service->pendingForUser($this->agent()));
+    }
+
+    public function test_meeting_five_minutes_past_end_is_eligible(): void
+    {
+        $this->activateCompany(10, now()->subDay());
+        $this->makeFollowUp(1, endedMinutesAgo: 6);
+
+        $pending = $this->service->pendingForUser($this->agent());
+
+        $this->assertNotNull($pending);
+        $this->assertSame(1, $pending->id);
+    }
+
+    public function test_meeting_that_ended_before_company_activation_is_never_eligible(): void
+    {
+        // Meeting ended an hour ago; the company only activated the feature 10 minutes ago.
+        $this->activateCompany(10, now()->subMinutes(10));
+        $this->makeFollowUp(1, endedMinutesAgo: 60);
+
+        $this->assertNull(
+            $this->service->pendingForUser($this->agent()),
+            'A meeting that ended before the feature was activated must never be prompted, even though the flag is on now.'
+        );
+    }
+
+    public function test_meeting_ending_after_activation_is_eligible(): void
+    {
+        $this->activateCompany(10, now()->subHours(2));
+        $this->makeFollowUp(1, endedMinutesAgo: 60);
+
+        $this->assertNotNull($this->service->pendingForUser($this->agent()));
+    }
+
+    public function test_already_logged_meeting_is_excluded(): void
+    {
+        $this->activateCompany(10, now()->subDay());
+        $this->makeFollowUp(1, endedMinutesAgo: 30, attendanceOutcomeLoggedAt: now()->subMinutes(5));
+
+        $this->assertNull($this->service->pendingForUser($this->agent()));
+    }
+
+    public function test_meeting_assigned_to_a_different_agent_is_excluded(): void
+    {
+        $this->activateCompany(10, now()->subDay());
+        $this->makeFollowUp(1, endedMinutesAgo: 30);
+
+        $this->assertNull($this->service->pendingForUser($this->agent(id: 6)));
+    }
+
+    public function test_feature_disabled_globally_returns_null_even_when_otherwise_eligible(): void
+    {
+        $this->activateCompany(10, now()->subDay());
+        $this->makeFollowUp(1, endedMinutesAgo: 30);
+        $this->setFeatureFlag('crm.meeting-attendance-confirmation', false);
+
+        $this->assertNull($this->service->pendingForUser($this->agent()));
+    }
+
+    public function test_activation_is_stamped_once_and_visible_on_the_same_call(): void
+    {
+        // No pre-existing activation timestamp: this call is the company's first
+        // observation of the flag being on. The just-ended meeting should still
+        // be excluded (it ended before "now", the stamp), but a meeting ending
+        // five minutes from now, checked ~5 minutes later, must find the stamp
+        // already in place rather than reading it stale.
+        $this->makeFollowUp(1, endedMinutesAgo: 30);
+
+        $this->service->pendingForUser($this->agent());
+
+        $company = Company::query()->find(10);
+        $this->assertNotNull(
+            $company->meeting_attendance_confirmation_enabled_at,
+            'enabledForCompany() should lazily stamp activation on first observation.'
+        );
+    }
+
+    /**
+     * Built in-memory rather than fetched via Eloquent: User::$with eagerly
+     * loads several relations (clientDetails, employeeDetail, ...) that this
+     * test's minimal schema doesn't have tables for, and pendingForUser()
+     * only ever reads $user->id / $user->company_id off the instance anyway.
+     */
+    private function agent(int $id = 5, int $companyId = 10): User
+    {
+        $user = new User();
+        $user->id = $id;
+        $user->company_id = $companyId;
+
+        return $user;
+    }
+
+    private function activateCompany(int $companyId, Carbon $enabledAt): void
+    {
+        DB::table('companies')->where('id', $companyId)->update([
+            'meeting_attendance_confirmation_enabled_at' => $enabledAt,
+        ]);
+        // Skip the lazy-stamp cache short-circuit so tests can set an explicit,
+        // pre-existing activation timestamp without it being overwritten.
+        Cache::put("meeting_attendance_confirmation:activated:{$companyId}", true, 3600);
+    }
+
+    private function makeFollowUp(
+        int $id,
+        int $endedMinutesAgo,
+        ?Carbon $attendanceOutcomeLoggedAt = null
+    ): void {
+        $duration = 30;
+        $start = now()->subMinutes($endedMinutesAgo + $duration);
+
+        DB::table('lead_follow_up')->insert([
+            'id' => $id,
+            'deal_id' => 1,
+            'lead_id' => null,
+            'next_follow_up_date' => $start,
+            'duration' => $duration,
+            'status' => 'scheduled',
+            'attendance_outcome_logged_at' => $attendanceOutcomeLoggedAt,
+        ]);
+    }
+
+    private function resetSchema(): void
+    {
+        foreach (['lead_follow_up', 'deals', 'leads', 'lead_agents', 'users', 'companies'] as $table) {
+            Schema::dropIfExists($table);
+        }
+    }
+
+    private function createMinimalSchema(): void
+    {
+        Schema::create('companies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('company_name')->nullable();
+            $table->timestamp('meeting_attendance_confirmation_enabled_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('company_id')->nullable();
+            $table->string('name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('status')->default('active');
+            $table->timestamps();
+        });
+
+        Schema::create('lead_agents', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('leads', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('company_id')->nullable();
+            $table->string('client_name')->nullable();
+            $table->unsignedInteger('lead_owner')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('company_id')->nullable();
+            $table->unsignedInteger('agent_id')->nullable();
+            $table->unsignedInteger('lead_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('lead_follow_up', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('deal_id')->nullable();
+            $table->unsignedInteger('lead_id')->nullable();
+            $table->unsignedInteger('meeting_type_id')->nullable();
+            $table->dateTime('next_follow_up_date')->nullable();
+            $table->integer('duration')->nullable();
+            $table->string('status')->nullable();
+            $table->string('attendance_outcome')->nullable();
+            $table->timestamp('attendance_outcome_logged_at')->nullable();
+            $table->unsignedInteger('attendance_outcome_logged_by')->nullable();
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
- Added `MeetingAttendanceOutcome` enum to represent various meeting outcomes (attended, no-show, rescheduled, cancelled, partial).
- Created `MeetingAttendanceConfirmationService` to handle the logic for confirming meeting outcomes and managing follow-ups.
- Introduced `MeetingAttendanceConfirmationController` for API endpoints to retrieve pending confirmations and submit outcomes.
- Developed UI components for attendance confirmation, including modals and hooks for managing state and API interactions.
- Updated database schema to include new columns for attendance outcomes in the `lead_follow_up` and `companies` tables.
- Enhanced `DealActivityEventService` to log meeting outcomes and integrate with existing event tracking.
- Added feature flags and configuration settings to control the attendance confirmation feature's availability.
- Implemented unit tests to ensure the functionality of the attendance confirmation service and its integration with the overall system.